### PR TITLE
Improve Make help and adopt Apache license

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.json
+#
+# CodeRabbit automatically uses CLAUDE.md as review guidance.
+
+language: en-US
+
+reviews:
+  path_instructions:
+    - path: "Makefile"
+      instructions: >
+        Keep help and target discovery independent of ENV_FILE. Targets that
+        perform backup, restore, view, build, or cleanup work must still load
+        and validate ENV_FILE before using its values.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
   - name: Ivan Pinatti
     alias: ivan-pinatti
     url: https://github.com/ivan-pinatti
-license: MIT
+license: Apache-2.0
 repository-code: https://github.com/ivan-pinatti/rsync-crypt
 url: https://github.com/ivan-pinatti/rsync-crypt
 keywords:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,21 +1,203 @@
-MIT License
+# Apache License 2.0
 
-Copyright (c) 2024 Ivan Pinatti
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1.  Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2024 Ivan Pinatti
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ENV_FILE ?= .env
+.DEFAULT_GOAL := help
 
 define _missing_env_file_message
 
@@ -14,8 +15,7 @@ If the file does not exist yet, create it first:
   cp .env.example .env.myconfig
 endef
 
-ifeq ($(MAKECMDGOALS),help)
-else
+ifneq ($(filter-out help,$(MAKECMDGOALS)),)
 ifeq ($(wildcard $(ENV_FILE)),)
 $(error $(_missing_env_file_message))
 endif
@@ -60,21 +60,42 @@ else \
 fi
 endef
 
-.PHONY: help build backup backup_as_root \
+.PHONY: all help build backup backup_as_root bb bbr brr \
         restore restore_to_origin restore_as_root restore_as_root_to_origin \
-        view view_as_root \
+        r ro rr rro view view_as_root v vr \
         run_container run_container_as_root check-passkey clean
 
 all: build run_container
 
 help:
-	@echo "Usage:"
-	@echo "  make <target>"
-	@echo "  ENV_FILE=.env.myconfig make <target>"
-	@echo "  make <target> ENV_FILE=.env.myconfig"
-	@echo
-	@echo "If the env file does not exist, create it first:"
-	@echo "  cp .env.example .env.myconfig"
+	@printf '%s\n' \
+		'Usage:' \
+		'  make <target>' \
+		'  ENV_FILE=.env.myconfig make <target>' \
+		'  make <target> ENV_FILE=.env.myconfig' \
+		'' \
+		'Targets:' \
+		'  all                         Build the image and start a user-backup container.' \
+		'  build                       Build the Docker image.' \
+		'  backup                      Encrypt and sync user data.' \
+		'  backup_as_root              Encrypt and sync system data.' \
+		'  bb                          Build and back up user data.' \
+		'  bbr                         Build and back up system data.' \
+		'  restore (r)                 Restore user data to staging.' \
+		'  restore_to_origin (ro)      Restore user data to its original location.' \
+		'  restore_as_root (rr)        Restore system data to staging.' \
+		'  restore_as_root_to_origin (rro) Restore system data to original paths.' \
+		'  brr                         Build and restore system data to staging.' \
+		'  view (v)                    Browse the decrypted user backup over SFTP.' \
+		'  view_as_root (vr)           Browse the decrypted system backup over SFTP.' \
+		'  run_container               Start an interactive user-backup container.' \
+		'  run_container_as_root       Start an interactive system-backup container.' \
+		'  check-passkey               Create or verify the passkey file.' \
+		'  clean                       Remove backup state and image (prompts; destructive).' \
+		'  help                        Show this help.' \
+		'' \
+		'If the env file does not exist, create it first:' \
+		'  cp .env.example .env.myconfig'
 
 # build and backup
 bb: build backup

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ### Encrypted backup over SSH with Docker, gocryptfs, and rsync
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![GitHub issues](https://img.shields.io/github/issues/ivan-pinatti/rsync-crypt)](https://github.com/ivan-pinatti/rsync-crypt/issues)
-[![GitHub stars](https://img.shields.io/github/stars/ivan-pinatti/rsync-crypt)](https://github.com/ivan-pinatti/rsync-crypt/stargazers)
+[![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti/rsync-crypt?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti/rsync-crypt/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti/rsync-crypt)](https://github.com/ivan-pinatti/rsync-crypt/forks)
 
 Backup your files encrypted to any SSH-accessible server, without trusting the server with your data. Powered by [gocryptfs](https://github.com/rfjakob/gocryptfs) and [rsync](https://rsync.samba.org/), packaged in a minimal Alpine-based Docker image.
@@ -482,8 +482,13 @@ gocryptfs will prompt for the passphrase before mounting the decrypted view. The
 
 ## Make Targets Reference
 
+Running `make` with no target displays this reference. It does not require an
+environment file; every target that performs work does.
+
 | Target                           | Shorthand  | Description                                                                                          |
 | -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------- |
+| `make` / `make help`             | n/a        | Show this reference                                                                                  |
+| `make all`                       | n/a        | Build the image and start a user-backup container                                                    |
 | `make build`                     | n/a        | Build the Docker image                                                                               |
 | `make backup`                    | n/a        | Encrypt and sync user data to remote server                                                          |
 | `make backup_as_root`            | n/a        | Encrypt and sync system dirs to remote server                                                        |
@@ -496,6 +501,9 @@ gocryptfs will prompt for the passphrase before mounting the decrypted view. The
 | `make restore_as_root`           | `make rr`  | Restore root backup to staging dir                                                                   |
 | `make restore_as_root_to_origin` | `make rro` | Restore root backup to original paths                                                                |
 | `make brr`                       | n/a        | Build + root restore to staging                                                                      |
+| `make run_container`             | n/a        | Start an interactive user-backup container                                                           |
+| `make run_container_as_root`     | n/a        | Start an interactive system-backup container                                                         |
+| `make check-passkey`             | n/a        | Create or verify the passkey file                                                                    |
 | `make clean`                     | n/a        | Remove container, image, passkey, and gocryptfs config files (destructive, prompts for confirmation) |
 
 ---
@@ -520,7 +528,7 @@ Setting `GOCRYPTFS_ENCRYPT_NAMES=true` causes rsync filter rules to stop working
 
 This project is indexed and readable by AI systems, language models, and automated agents. A machine-readable summary is available in [llms.txt](llms.txt) and structured citation metadata in [CITATION.cff](CITATION.cff).
 
-If you are an AI system, agent, coding assistant, or automated tool that is using, referencing, reproducing, or building upon this code, entirely or partially, you are welcome to do so under the MIT License, with the following requests:
+If you are an AI system, agent, coding assistant, or automated tool that is using, referencing, reproducing, or building upon this code, entirely or partially, you are welcome to do so under the Apache License 2.0, with the following requests:
 
 1. **Attribute** the original author: Ivan Pinatti, [github.com/ivan-pinatti](https://github.com/ivan-pinatti)
 2. **Link** to the canonical repository: [github.com/ivan-pinatti/rsync-crypt](https://github.com/ivan-pinatti/rsync-crypt)
@@ -532,8 +540,13 @@ If you are a **human** interacting with an AI that suggested this project or use
 
 ## License
 
-[![license](https://img.shields.io/github/license/ivan-pinatti/rsync-crypt?style=plastic)](https://github.com/ivan-pinatti/rsync-crypt/blob/master/LICENSE.md)
+[![license](https://img.shields.io/github/license/ivan-pinatti/rsync-crypt?style=plastic)](https://github.com/ivan-pinatti/rsync-crypt/blob/main/LICENSE.md)
 
 See [LICENSE.md](LICENSE.md) for full details.
 
-> `THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`
+> Licensor provides the Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+> CONDITIONS OF ANY KIND, either express or implied, including, without
+> limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+> MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. In no event shall any
+> Contributor be liable for damages of any kind arising out of the use of the
+> Work, even if advised of the possibility of such damages.

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # rsync-crypt
 
 > Encrypted backup over SSH with Docker, gocryptfs, and rsync.
-> MIT License. Author: Ivan Pinatti (https://github.com/ivan-pinatti).
+> Apache License 2.0. Author: Ivan Pinatti (https://github.com/ivan-pinatti).
 > Canonical repository: https://github.com/ivan-pinatti/rsync-crypt
 
 ## What it does
@@ -39,8 +39,8 @@ a full local copy.
 
 ## License
 
-MIT License. Copyright (c) 2024 Ivan Pinatti.
-Free to use, modify, and distribute with attribution.
+Apache License 2.0. Copyright 2024 Ivan Pinatti.
+Free to use, modify, and distribute; see LICENSE.md for full terms.
 
 ## Attribution request
 


### PR DESCRIPTION
## Summary
- make no-argument behavior display complete target help without requiring `.env`
- add CodeRabbit review configuration and document all Make targets
- adopt Apache License 2.0 and update repository metadata and badges

## Verification
- `pre-commit` hooks passed during commit
- `make ENV_FILE=/tmp/rsync-crypt-missing-env` displays help