### PR TITLE
ci: add release and pre-commit workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,40 @@
+name: Merge
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Create Tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
+    steps:
+      - name: Create Tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          dry_run: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: .*
+
+  create-release:
+    name: Create Release
+    needs: [create-tag]
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1.21.0
+        with:
+          tag: ${{ needs.create-tag.outputs.new_tag }}
+          name: Release ${{ needs.create-tag.outputs.new_tag }}
+          body: ${{ needs.create-tag.outputs.changelog }}
+          generateReleaseNotes: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,3 +44,4 @@ jobs:
           tag: ${{ needs.create-tag.outputs.new_tag }}
           name: Release ${{ needs.create-tag.outputs.new_tag }}
           body: ${{ needs.create-tag.outputs.changelog }}
+          allowUpdates: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,21 +5,26 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
   create-tag:
     name: Create Tag
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: write
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
       changelog: ${{ steps.tag_version.outputs.changelog }}
     steps:
       - name: Create Tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           dry_run: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,11 +35,12 @@ jobs:
     needs: [create-tag]
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: write
     steps:
       - name: Create GitHub release
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.create-tag.outputs.new_tag }}
           name: Release ${{ needs.create-tag.outputs.new_tag }}
           body: ${{ needs.create-tag.outputs.changelog }}
-          generateReleaseNotes: true

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -1,0 +1,23 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -15,9 +15,11 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![GitHub issues](https://img.shields.io/github/issues/ivan-pinatti/rsync-crypt)](https://github.com/ivan-pinatti/rsync-crypt/issues)
-[![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti/rsync-crypt?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti/rsync-crypt/stargazers)
+[![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti/rsync-crypt)](https://github.com/ivan-pinatti/rsync-crypt/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti/rsync-crypt)](https://github.com/ivan-pinatti/rsync-crypt/forks)
 
 Backup your files encrypted to any SSH-accessible server, without trusting the server with your data. Powered by [gocryptfs](https://github.com/rfjakob/gocryptfs) and [rsync](https://rsync.samba.org/), packaged in a minimal Alpine-based Docker image.


### PR DESCRIPTION
## Summary
- add automatic tag and GitHub release creation on pushes to main
- run the existing pre-commit hooks for pull requests
- align the README stars badge with the other repository badges

## Validation
- pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release creation with version tagging and generated release notes after changes are merged.
  * Added automated pull request validation checks before merging.
  * Added weekly automated updates for GitHub Actions tooling.
  * Improved workflow security with restricted permissions and controlled concurrent runs.

* **Documentation**
  * Refreshed the repository status badge for a cleaner presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->