### PR TITLE
ci: add renovate and cover pre-commit hooks with dependabot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,13 @@ DOCKER_IMAGE_TAG_NAME="local/gocryptfs"
 DOCKER_IMAGE_TAG_VERSION="1.0.0"
 
 # Alpine Linux base image version used in the Dockerfile.
+# renovate: datasource=docker depName=alpine versioning=docker
 ALPINE_VERSION="3.23"
 
 # gocryptfs release to install inside the Docker image.
+# Deliberately not tracked by Renovate: this is an apk version constraint, not a
+# Docker tag, and the resolved build (2.5.4-r8) differs in supported flags.
+# Bump it by hand after checking the Alpine community repo.
 GOCRYPTFS_VERSION="2.5"
 
 #===============================================================

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,43 @@
 version: 2
 
+# Dependabot handles GitHub Actions and pre-commit hooks.
+# Renovate handles .tool-versions and the version pins in .env.example,
+# see renovate.json5.
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: America/Toronto
+    labels:
+      - dependencies
+      - github-actions
     commit-message:
       prefix: "ci"
+      include: scope
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Toronto
+    labels:
+      - dependencies
+      - pre-commit
+    commit-message:
+      prefix: "chore"
+      include: scope
+    open-pull-requests-limit: 5
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,58 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Dependabot handles GitHub Actions and pre-commit hooks, see dependabot.yml.
+  // Renovate handles the asdf tool versions and the Alpine pin in .env.example,
+  // neither of which Dependabot can parse.
+  extends: ["config:recommended"],
+
+  // config:recommended enables a standing "Dependency Dashboard" issue that
+  // never resolves on its own; PRs still open on the normal schedule below
+  // without it, this just drops the one consolidated overview issue.
+  dependencyDashboard: false,
+
+  timezone: "America/Toronto",
+  schedule: ["before 7am on Monday"],
+
+  labels: ["dependencies"],
+  commitMessagePrefix: "chore:",
+
+  // Keep PR volume manageable so CI is not overwhelmed.
+  prConcurrentLimit: 5,
+  prHourlyLimit: 2,
+  automerge: false,
+
+  // Dependabot owns these two ecosystems; disabling them here avoids
+  // duplicate pull requests for the same update.
+  enabledManagers: ["asdf", "custom.regex"],
+
+  packageRules: [
+    {
+      matchManagers: ["asdf"],
+      groupName: "asdf tool versions",
+      groupSlug: "asdf-tools",
+      labels: ["dependencies", "tooling"],
+    },
+    {
+      matchManagers: ["custom.regex"],
+      labels: ["dependencies", "docker"],
+    },
+  ],
+
+  customManagers: [
+    {
+      // Matches the pattern:
+      //   # renovate: datasource=<ds> depName=<name> [versioning=<scheme>]
+      //   VAR="<currentValue>"
+      //
+      // GOCRYPTFS_VERSION is intentionally left unannotated: it is an apk
+      // version constraint rather than a Docker tag, so it is bumped by hand.
+      customType: "regex",
+      managerFilePatterns: ["/^\\.env\\.example$/"],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[^\\s]+))?\\s+[A-Z0-9_]+="(?<currentValue>[^"]+)"',
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Dependabot cannot parse `.tool-versions` or the version pins in `.env.example`, and the Dockerfile's `ARG ALPINE_VERSION` has no default for its docker manager to resolve. Those pins were going stale with nothing watching them.

This splits the work the same way as `docker-torrent-box-with-vpn`:

| Pin | Owner |
| --- | --- |
| `.github/workflows/*` action SHAs | Dependabot |
| `.pre-commit-config.yaml` hook revs | Dependabot (new) |
| `.tool-versions` (github-cli, pre-commit) | Renovate (new) |
| `ALPINE_VERSION` in `.env.example` | Renovate (new) |
| `GOCRYPTFS_VERSION` | manual, on purpose |

`enabledManagers` restricts Renovate to `asdf` and `custom.regex` so it cannot open duplicate PRs for the two ecosystems Dependabot already owns.

`GOCRYPTFS_VERSION` is deliberately left unannotated: it is an apk version constraint rather than a Docker tag, and the resolved build (2.5.4-r8) differs in which flags it supports, so an automated bump could break the image quietly.

## Validation

- `renovate-config-validator --strict` passes on `.github/renovate.json5`
- the custom manager regex was tested against `.env.example`: it matches `alpine 3.23` and correctly ignores the unannotated `GOCRYPTFS_VERSION` (1 dependency found)
- `pre-commit run` passes on all changed files

## Note

Renovate is not yet enabled on this repository, so the config is inert until `rsync-crypt` is added to the Mend Renovate app's repository list.