### PR TITLE
chore: enable the Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,10 +6,14 @@
   // neither of which Dependabot can parse.
   extends: ["config:recommended"],
 
-  // config:recommended enables a standing "Dependency Dashboard" issue that
-  // never resolves on its own; PRs still open on the normal schedule below
-  // without it, this just drops the one consolidated overview issue.
-  dependencyDashboard: false,
+  // Kept on despite the standing, never-resolving tracking issue it opens.
+  // Without it, "Renovate found nothing to update" and "Renovate silently
+  // stopped seeing your dependencies" look identical, and the dashboard is the
+  // only place Renovate reports detection errors and rate-limited updates.
+  // That matters most for the custom regex manager below, which depends on a
+  // hand-written pattern that will match nothing, silently, if .env.example is
+  // renamed or its `# renovate:` annotation format changes.
+  dependencyDashboard: true,
 
   timezone: "America/Toronto",
   schedule: ["before 7am on Monday"],


### PR DESCRIPTION
Flips `dependencyDashboard` to `true` in `.github/renovate.json5`.

## Why

With the dashboard off, "Renovate found nothing to update" and "Renovate
silently stopped seeing your dependencies" look identical. That is not
hypothetical: Dependabot discarded every candidate release across these
repositories for days because of GitHub's undocumented three day cooldown
default, and it presented exactly as everything being up to date. The
dashboard is the only place Renovate surfaces detection errors and
rate-limited updates.

It matters more here than in a repository running only off-the-shelf
managers, because this config carries a **custom regex manager** watching the
annotated version pins in `.env.example`. That pattern will match nothing,
silently, if the file is renamed or its `# renovate:` annotation format
changes, and without the dashboard there is no signal that it stopped
working.

Cost is one permanently open tracking issue.

Already done in `pre-commit-checklists`, `pre-commit-checklists-demo`, and
`github-template`. This brings `rsync-crypt` in line.

https://claude.ai/code/session_014BRn6NyNenocZz1hVeBEnS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled the dependency update dashboard to provide clearer visibility into update detection and reporting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->