### PR TITLE
fix(restore): stop rsync exit 23 and 24 looping forever

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-<!-- cspell:words checkmake coderabbit coderabbitai maxbodylength mbake minphony phonydeclared -->
+<!-- cspell:words checkmake coderabbit coderabbitai maxbodylength mbake minphony mktemp phonydeclared shutil zizmor -->
 
 ## Outstanding: finish the pre-commit-checklists adoption
 
@@ -213,6 +213,34 @@ unaffected and still correct; only the note is stale.
 Worth deciding whether that line should name an exact revision at all, given
 it will drift again on the next Alpine rebuild. The useful part of the note is
 the `-bs` flag warning underneath it, which is not version-specific.
+
+### 7. Restore and view sessions write to a predictable shared path
+
+**Status:** open. Raised by CodeRabbit on the formatting pull request, against
+pre-existing code.
+
+`scripts/restore.sh` and `scripts/view.sh` write their session files, including
+`sshd_config` and host keys, to a fixed location rather than a private
+directory. A `mktemp -d` per run, with every reference routed through it and an
+exit trap to remove it, would stop one session colliding with another and stop
+the material sitting somewhere predictable.
+
+Not folded into the rsync exit-status fix: that change is about a retry loop
+and carries a regression test aimed at it, and mixing a temp-directory rework
+into it would make both harder to review.
+
+### 8. `tests/conftest.py` invokes `docker` by bare name
+
+**Status:** open, low priority. Also raised on the formatting pull request.
+
+Every Docker call passes the literal string `docker` to `subprocess.run`, so
+resolution depends on whatever `PATH` the suite inherits. Resolving it once
+with `shutil.which` (the suite already imports `shutil` for its
+`require_docker` check) and reusing that path would remove the ambiguity.
+
+Low priority because the suite already refuses to run when `shutil.which`
+cannot find Docker, so the realistic failure is a surprising binary rather
+than a missing one.
 
 ## CodeRabbit: automatic reviews stop silently on a busy branch
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,7 @@
 # TODO
 
-<!-- cspell:words checkmake coderabbit coderabbitai maxbodylength mbake minphony mktemp phonydeclared shutil zizmor -->
+<!-- cspell:words checkmake coderabbit maxbodylength mbake -->
+<!-- cspell:words minphony mktemp phonydeclared shutil -->
 
 ## Outstanding: finish the pre-commit-checklists adoption
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -77,16 +77,36 @@ trap 'echo "Restore interrupted, cleaning up..."; fusermount -u ${__restore_decr
 # Pull encrypted data from remote
 #===============================================================
 
+__retry_delay=5
+__retry_delay_max=300
+
 while true; do
   # rsync remote encrypted copy of data to local copy:
-  if rsync --bwlimit="${__rsync_rate_limit}" -P -a -z --stats -h --delete --exclude-from="${__restore_exclude_pattern_file}" "${__restore_origin}"/ "${__restore_encrypted_folder}"; then
+  __rsync_exit=0
+  rsync --bwlimit="${__rsync_rate_limit}" -P -a -z --stats -h --delete --exclude-from="${__restore_exclude_pattern_file}" "${__restore_origin}"/ "${__restore_encrypted_folder}" || __rsync_exit=$?
+  if [ "${__rsync_exit}" -eq 0 ]; then
     echo "rsync succeeded -> encrypted data from ${__restore_origin} is ready in ${__restore_encrypted_folder}"
+    break
+  elif [ "${__rsync_exit}" -eq 23 ] || [ "${__rsync_exit}" -eq 24 ]; then
+    # 23 is a partial transfer, 24 is files that vanished mid transfer. Neither
+    # is retriable: the next attempt hits the same unreadable or already gone
+    # files and returns the same status, so looping on them never terminates.
+    # backup.sh has treated these as success-with-warning since they caused
+    # exactly that infinite loop there; restore.sh was missed at the time.
+    echo "rsync completed with warnings (exit ${__rsync_exit}): some files were skipped (locked, unreadable, or vanished during transfer)."
+    echo "The restore is otherwise complete."
     break
   else
     if ! ${__rsync_loop}; then
-      echo "rsync failed"
+      echo "rsync failed (exit ${__rsync_exit})"
       exit 1
     fi
+    # Back off between attempts. This loop previously had no delay at all, so
+    # a persistent failure spun as fast as rsync could return, hammering the
+    # remote. Mirrors backup.sh: 5s doubling to a 300s ceiling.
+    echo "rsync failed (exit ${__rsync_exit}), retrying in ${__retry_delay}s..."
+    sleep "${__retry_delay}"
+    __retry_delay=$((__retry_delay * 2 > __retry_delay_max ? __retry_delay_max : __retry_delay * 2))
   fi
 done
 

--- a/tests/test_rsync_exit_handling.py
+++ b/tests/test_rsync_exit_handling.py
@@ -45,7 +45,7 @@ def test_partial_transfer_statuses_break_the_loop(name):
     branch = re.search(
         r"elif \[ \"\$\{__rsync_exit\}\" -eq 23 \].*?(?=\n  else\b)",
         body,
-        re.S,
+        re.DOTALL,
     )
     assert branch, f"{name}: could not locate the 23/24 branch"
     assert "break" in branch.group(0), (

--- a/tests/test_rsync_exit_handling.py
+++ b/tests/test_rsync_exit_handling.py
@@ -41,15 +41,24 @@ def test_partial_transfer_statuses_break_the_loop(name):
     )
 
     # The branch that matches 23/24 has to break out, not fall through to the
-    # retry path. Grab the elif block and assert it contains a break.
+    # retry path.
     branch = re.search(
         r"elif \[ \"\$\{__rsync_exit\}\" -eq 23 \].*?(?=\n  else\b)",
         body,
         re.DOTALL,
     )
     assert branch, f"{name}: could not locate the 23/24 branch"
-    assert "break" in branch.group(0), (
-        f"{name}: the 23/24 branch does not break, so it still retries"
+
+    # An executable `break`, not the word appearing in a comment or a string.
+    # `"break" in branch` passed against a branch whose only break was
+    # `# we should break here`, which is why this checks for the statement on
+    # its own line.
+    executable_break = any(
+        line.strip() == "break" for line in branch.group(0).splitlines()
+    )
+    assert executable_break, (
+        f"{name}: the 23/24 branch has no executable break statement, so it "
+        f"falls through to the retry path and loops"
     )
 
 
@@ -61,7 +70,17 @@ def test_retry_path_backs_off(name):
     assert re.search(r"sleep \"\$\{__retry_delay\}\"", body), (
         f"{name} defines a retry delay but never sleeps on it"
     )
-    assert "__retry_delay_max" in body, f"{name} has no ceiling on its backoff"
+
+    # The cap has to be used by the computation, not merely defined. Asserting
+    # only that the name appears in the file passed against a version where
+    # the assignment had been reduced to `__retry_delay * 2` with the ceiling
+    # left dangling, which is unbounded growth with a reassuring variable name.
+    assignment = re.search(r"__retry_delay=\$\(\(.*?\)\)", body, re.DOTALL)
+    assert assignment, f"{name}: no arithmetic update of __retry_delay found"
+    assert "__retry_delay_max" in assignment.group(0), (
+        f"{name}: the backoff grows without reference to __retry_delay_max, "
+        f"so the ceiling is never applied"
+    )
 
 
 @pytest.mark.parametrize("name", LOOPING_SCRIPTS)

--- a/tests/test_rsync_exit_handling.py
+++ b/tests/test_rsync_exit_handling.py
@@ -1,0 +1,74 @@
+"""The rsync retry loops must not spin forever on a partial transfer.
+
+rsync exit 23 means a partial transfer (files skipped as unreadable or
+locked) and 24 means files vanished between the file list being built and
+the transfer running. Neither is retriable: a second attempt hits the same
+files and returns the same status, so a loop that treats them as failures
+never terminates.
+
+backup.sh has treated both as success-with-warning since they caused exactly
+that infinite loop. restore.sh carried the same loop shape unfixed, which is
+what these tests guard against coming back.
+
+These are static checks on the scripts rather than live rsync runs: making a
+real rsync return 23 needs an unreadable file inside a transfer, and making
+it return 24 needs a file deleted mid-run, neither of which is reproducible
+enough to gate a suite on. The failure being guarded is a missing branch, so
+the branch is what gets asserted.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from conftest import REPO_ROOT
+
+LOOPING_SCRIPTS = ["backup.sh", "restore.sh"]
+
+
+def _script(name):
+    return (REPO_ROOT / "scripts" / name).read_text()
+
+
+@pytest.mark.parametrize("name", LOOPING_SCRIPTS)
+def test_partial_transfer_statuses_break_the_loop(name):
+    """23 and 24 must be handled, and must break rather than retry."""
+    body = _script(name)
+    assert "-eq 23" in body and "-eq 24" in body, (
+        f"{name} does not special-case rsync exit 23/24, so a partial "
+        f"transfer is treated as a retriable failure and loops forever"
+    )
+
+    # The branch that matches 23/24 has to break out, not fall through to the
+    # retry path. Grab the elif block and assert it contains a break.
+    branch = re.search(
+        r"elif \[ \"\$\{__rsync_exit\}\" -eq 23 \].*?(?=\n  else\b)",
+        body,
+        re.S,
+    )
+    assert branch, f"{name}: could not locate the 23/24 branch"
+    assert "break" in branch.group(0), (
+        f"{name}: the 23/24 branch does not break, so it still retries"
+    )
+
+
+@pytest.mark.parametrize("name", LOOPING_SCRIPTS)
+def test_retry_path_backs_off(name):
+    """A persistent failure must not spin as fast as rsync can return."""
+    body = _script(name)
+    assert "__retry_delay" in body, f"{name} has no retry delay"
+    assert re.search(r"sleep \"\$\{__retry_delay\}\"", body), (
+        f"{name} defines a retry delay but never sleeps on it"
+    )
+    assert "__retry_delay_max" in body, f"{name} has no ceiling on its backoff"
+
+
+@pytest.mark.parametrize("name", LOOPING_SCRIPTS)
+def test_rsync_exit_status_is_captured(name):
+    """`if rsync ...; then` discards the status, which is how this was missed."""
+    body = _script(name)
+    assert re.search(r"rsync .*\|\| __rsync_exit=\$\?", body), (
+        f"{name} does not capture rsync's exit status, so it cannot tell "
+        f"23 or 24 apart from a real failure"
+    )


### PR DESCRIPTION
`restore.sh` had **the defect `CLAUDE.md` documents as already fixed**, in the other script.

Your own note reads:

> Exit 23 = partial transfer (some files skipped/unreadable), exit 24 = vanished files. Both are treated as success-with-warning (break loop), not as retriable failures. With `RSYNC_LOOP=true` these used to cause infinite retry loops.

`backup.sh` implements that at line 174. **`restore.sh` contained no reference to 23 or 24 at all.** So with `RSYNC_LOOP=true`, a restore that skipped an unreadable file, or raced a file being deleted, retried the same transfer forever and got the same status every time.

It was **worse than the original bug**. `backup.sh` at least backs off 5s doubling to a 300s ceiling; `restore.sh` had no sleep whatsoever, so a persistent failure spun as fast as rsync could return, against a remote server over SSH.

## The root cause

```bash
if rsync ...; then          # throws the exit code away
```

That leaves only success-or-failure, which is exactly why 23 and 24 could not be told apart from a real error. Now the status is captured with `|| __rsync_exit=$?`, matching `backup.sh`.

## Tests

`tests/test_rsync_exit_handling.py`, parameterised over **both** scripts, three assertions each:

1. the 23/24 branch exists and `break`s rather than falling through to retry
2. the retry path sleeps on a bounded, backing-off delay
3. rsync's exit status is captured at all

They are static checks rather than live rsync runs: provoking a real 23 needs an unreadable file mid-transfer and a real 24 needs one deleted during the run, neither reproducible enough to gate a suite on. The failure being guarded is a *missing branch*, so the branch is what gets asserted.

**Verified as a real regression guard, not a test fitted to the code:**

| Against | Result |
| --- | --- |
| previous `restore.sh` | **3 failed**, 3 passed |
| this `restore.sh` | 6 passed |

The `backup.sh` three pass either way, confirming they are not incidentally green.

## Provenance

Found by CodeRabbit reviewing #15, against code that PR only reindented. Two other findings from that review are pre-existing hardening rather than defects, and are recorded in `docs/TODO.md` as items 7 and 8: session files written to a predictable shared path, and `docker` invoked by bare name in the test suite.

45 tests pass; gate clean.

https://claude.ai/code/session_014BRn6NyNenocZz1hVeBEnS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved encrypted-data restoration when some files are skipped or no longer available, with clear warnings.
  - Added automatic retries for other transfer failures, using increasing delays up to five minutes.
  - Retrying can still be disabled to preserve immediate failure behavior when needed.
  - Improved handling of partial transfer results so recoverable interruptions no longer unnecessarily stop restoration.

- **Documentation**
  - Added notes for future improvements related to temporary paths and Docker detection during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->