### PR TITLE
docs: make the contribution steps match the gates that now enforce them

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,39 @@ Contributions, bug reports, and feature requests are welcome!
 1. [Open an issue](https://github.com/ivan-pinatti/rsync-crypt/issues/new) to report a bug or
    suggest a feature
 2. Fork the repository
-3. Create a feature branch (`git checkout -b feature/my-feature`)
-4. Commit your changes
-5. Open a pull request
+3. Install the hooks: `pre-commit install`. This wires up both the `pre-commit`
+   and `commit-msg` stages; without it the commit message check never runs
+   locally and fails in CI instead
+4. Create a feature branch (`git checkout -b fix/my-thing`). Branch names must
+   be lowercase slugs, optionally prefixed (`fix/`, `docs/`, `chore/`); commits
+   straight to `main` are blocked
+5. Commit your changes using
+   [Conventional Commits](https://www.conventionalcommits.org/): `feat: add x`,
+   `fix(scope): correct y`. Valid types are `feat`, `fix`, `docs`, `style`,
+   `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. **A message
+   that is not in this form is rejected at commit time**
+6. Open a pull request as a **draft** first, let the checks run, fix anything
+   they report, then mark it ready for review
+7. Address the review comments, and merge once everything is green
 
-Please make sure pre-commit hooks pass before submitting (`pre-commit run --all-files`).
+### What the hooks need installed
+
+Linting comes from
+[ivan-pinatti/pre-commit-checklists](https://github.com/ivan-pinatti/pre-commit-checklists),
+pinned in `.pre-commit-config.yaml`. Running `pre-commit run --all-files`
+locally needs more than the tool itself does:
+
+| Needed for | Why |
+| ---------- | --- |
+| Docker or Podman | `hadolint`, `actionlint` and `dotenv-linter` run in containers |
+| Node | Prettier, markdownlint, cspell and the link checker |
+| Python 3.10+ | `zizmor`, installed into its own hook environment |
+
+Everything else is fetched and cached by `pre-commit` on first run.
+
+CI never rewrites your branch. A hook that can fix something will fix it on
+your machine, but in CI the same finding fails the job and waits for you to
+push the fix.
 
 ---
 


### PR DESCRIPTION
The Contributing section told contributors to "commit your changes" and to make sure pre-commit passes. **After the checklist adoption, following those steps literally gets your commit rejected.**

Verified against the library's own `check-commit-msg.sh`:

| Message | Result |
| --- | --- |
| `Add my feature` (what step 4 implied) | **REJECTED** |
| `feat: add my feature` | accepted |

## What changed

The steps now say what is actually enforced:

- **`pre-commit install` first**, because it is what wires the `commit-msg` stage up at all. Without it the message check never runs locally and the contributor discovers it in CI.
- **Branch naming**, and that commits to `main` are blocked. Example changed from `feature/my-feature` to `fix/my-thing`; both are accepted, but the new one matches the convention actually used here.
- **Conventional Commits**, with the valid type list spelled out. That list is copied from `COMMIT_TYPES` in `check-commit-msg.sh`, not remembered.
- **Draft first, then ready.** That ordering is the whole point of `drafts: false` in `.coderabbit.yaml`; doing it the other way spends a review slot on a diff the linters have not seen.

## New: what the hooks need locally

Nothing told anyone this before, and the tool itself needs none of it:

| Needed for | Why |
| --- | --- |
| Docker or Podman | `hadolint`, `actionlint`, `dotenv-linter` run in containers |
| Node | Prettier, markdownlint, cspell, link checker |
| Python 3.10+ | `zizmor`, in its own hook environment |

Also states plainly that **CI never rewrites your branch** — a fixable finding fails the job and waits for you to push, which is the decision recorded in `CLAUDE.md`.

## Verification

Every claim was checked against the scripts rather than written from memory: both commit examples and the branch example are accepted, and the documented type list matches `COMMIT_TYPES` exactly. All 14 checklists pass.

## A correction

I had been describing this work as "the README still documents the old hook set". It never documented any hook set — it had one line about pre-commit. The real defect was narrower and worse: the documented steps actively conflicted with the gates.

https://claude.ai/code/session_014BRn6NyNenocZz1hVeBEnS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with pre-commit hook setup instructions.
  * Added requirements for lowercase feature branch names and Conventional Commits.
  * Clarified expectations for opening draft pull requests and resolving review comments.
  * Documented required Docker/Podman, Node.js, and Python tooling.
  * Explained that CI reports fixable findings without automatically rewriting branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->