### PR TITLE
docs: record that parallel agents need separate worktrees

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -36,6 +36,8 @@
     "sshfs",
     "unincluded",
     "venv",
+    "worktree",
+    "worktrees",
     "xchacha",
     "yamllint",
     "Zcash"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,27 @@ findings. `checklist-dev-dotenv` cannot be passed `--ignore-checks`: every
 its first argument, so an `args:` entry replaces that name instead of reaching
 the tool. The library documents the local-hook copy as the supported way out.
 
+### Parallel agents need separate worktrees
+
+More than one agent working in this repository at the same time must each get
+their own `git worktree`. They cannot share the checkout.
+
+This was learned the hard way: two agents were dispatched into
+`/home/ivan/wo/personal/rsync-crypt` at once to verify two different
+dependency pull requests. Each needed its own branch checked out, so they
+took turns swapping the shared working tree out from under each other. One of
+them noticed its branch had changed mid-task and moved itself into a
+worktree; the other never noticed, which is the worse outcome, because a
+verification run against the wrong branch still reports a result.
+
+Nothing was lost that time. The failure mode to avoid is a passing gate or a
+green test run that was measured against a branch nobody intended, which is
+indistinguishable from a real pass in the report that comes back.
+
+When dispatching with the Agent tool, pass `isolation: "worktree"` so each
+agent gets an isolated copy. A worktree costs a few hundred milliseconds and
+some disk, and is removed automatically if unchanged.
+
 ## User Preferences
 
 - No em-dashes (`—` or `--`) in prose; use commas or parentheses instead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,13 +117,13 @@ the tool. The library documents the local-hook copy as the supported way out.
 More than one agent working in this repository at the same time must each get
 their own `git worktree`. They cannot share the checkout.
 
-This was learned the hard way: two agents were dispatched into
-`/home/ivan/wo/personal/rsync-crypt` at once to verify two different
-dependency pull requests. Each needed its own branch checked out, so they
-took turns swapping the shared working tree out from under each other. One of
-them noticed its branch had changed mid-task and moved itself into a
-worktree; the other never noticed, which is the worse outcome, because a
-verification run against the wrong branch still reports a result.
+This was learned the hard way: two agents were dispatched into this
+repository's checkout at once to verify two different dependency pull requests.
+Each needed its own branch checked out, so they took turns swapping the shared
+working tree out from under each other. One of them noticed its branch had
+changed mid-task and moved itself into a worktree; the other never noticed,
+which is the worse outcome, because a verification run against the wrong
+branch still reports a result.
 
 Nothing was lost that time. The failure mode to avoid is a passing gate or a
 green test run that was measured against a branch nobody intended, which is


### PR DESCRIPTION
Two agents were dispatched into this checkout at the same time to verify two different dependency pull requests (#7 and #9). Each needed its own branch checked out, so they took turns swapping the shared working tree out from under each other.

One noticed its branch had changed mid-task and moved itself into a `git worktree`. **The other never noticed**, which is the worse outcome: a verification run against the wrong branch still reports a result, and a passing gate measured against a branch nobody intended is indistinguishable from a real pass in the report that comes back.

Nothing was lost that time, and both verifications were sound in the end. Recorded so the next dispatch passes `isolation: "worktree"` rather than rediscovering it.

Also adds `worktree` and `worktrees` to `.cspell.json`.

All 14 checklists pass.

## Unrelated note from merging #9

That PR bumped `.tool-versions` to `github-cli 2.97.0`, which was not installed locally, so `gh` stopped working in this directory immediately after the merge (asdf refuses to fall back). Installed 2.97.0 to match. Worth knowing that a `.tool-versions` bump is inert for the repository's behaviour but not for anyone's local tooling.

https://claude.ai/code/session_014BRn6NyNenocZz1hVeBEnS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using separate Git worktrees when running agents in parallel.
  * Documented how to configure agent dispatches for isolated worktrees.
  * Clarified common issues that can occur when concurrent work shares a checkout.

* **Chores**
  * Updated spell-checking configuration to recognize worktree-related terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->