### PR TITLE
chore: bump pre-commit-checklists to v2.2.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/ivan-pinatti/pre-commit-checklists
-    rev: v2.2.0
+    rev: v2.2.2
     hooks:
       # Large-file, merge-conflict and line-ending hygiene. No selector needed.
       - id: checklist-basic


### PR DESCRIPTION
Picks up the branch-name fix released upstream in
[pre-commit-checklists#13](https://github.com/ivan-pinatti/pre-commit-checklists/pull/13).

## What was broken

`checklist-git-valid-branches` allowed only lowercase alphanumerics separated by `/` or `-`, so both dependency bots' default branch names failed it:

| Branch | Before | After |
| --- | --- | --- |
| `dependabot/github_actions/…` | rejected (underscore) | **valid** |
| `dependabot/pre_commit/…` | rejected (underscore) | **valid** |
| `renovate/alpine-3.x` | rejected (dot) | **valid** |

That is not hypothetical: it is **every** Dependabot PR this repo will ever receive, plus any Renovate branch carrying a dotted version. Both Dependabot shapes above are ones this repository has actually seen.

Reconfiguring the bots was not an option. Dependabot's ecosystem segment is generated and has no configuration knob, confirmed against GitHub's own options reference; `pull-request-branch-name.separator` changes the character *between* segments, not the underscore inside `github_actions`. Renovate alone could have been fixed with `branchNameStrict`, which would have left half the problem in place.

## Also in v2.2.2: the check was locale dependent

`café/accents` was **accepted** under `en_CA.UTF-8` and **rejected** under `LC_ALL=C`, so the gate answered differently depending on the ambient locale of whoever ran it, which for a CI check is a silent inconsistency.

Fixed upstream with `export LC_ALL=C`. Worth recording why the obvious alternative does not work: swapping to a POSIX class would **not** have fixed it, because `[[:lower:]]` is itself governed by `LC_CTYPE`. Verified both directions:

```
en_CA.UTF-8   [a-z]+ -> accepted   [[:lower:]]+ -> accepted
C             [a-z]+ -> rejected   [[:lower:]]+ -> rejected
```

## Why it matters beyond tidiness

A bot PR no longer shows a failing check for nothing. That is also the precondition for ever letting one merge without a human, which is the stated goal for these.

## Verification

All three branch shapes tested against the bumped pin, all 14 checklists pass, 39 tests pass.

https://claude.ai/code/session_014BRn6NyNenocZz1hVeBEnS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-commit checklist configuration to the latest maintained revision, improving consistency and validation during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->