### PR TITLE
docs: record that force-pushing is never allowed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,19 @@ Branch out, commit, push, open a draft PR, mark it ready, wait for the gates
 and CodeRabbit, address the comments, and merge once green. Branch names are
 lowercase slugs (`fix/flaky-test`); commit messages are Conventional Commits.
 
+Never force-push. Not `--force`, not `--force-with-lease`, not on a branch
+nobody else is reading, not to tidy up a history. A force-push destroys commits
+on the remote that nobody agreed to lose, and on a dependency bot's branch it
+also rewrites work this account did not author.
+
+That rules out rebasing a pushed branch, because a rebase is what makes the
+force necessary. To bring a stale branch up to date, merge the base branch into
+it and the push stays a fast-forward. If a branch has already been rebased and
+diverged from its remote, merge the remote ref back into it so the remote tip
+becomes an ancestor again, then push normally. `renovate/alpine-3.x` was
+recovered exactly that way in #8. When neither is possible, push a new branch
+and supersede the old pull request.
+
 ### Selectors match the library's templates
 
 Both selectors that once deviated no longer do, as of `rev: v2.2.0`.


### PR DESCRIPTION
Writes the rule into `CLAUDE.md` under "Branch, PR, gates, then merge": force-pushing is never allowed, in any form, on any branch.

Also records the part that is easy to miss, because it is what actually caused the situation: rebasing a pushed branch is what creates the need to force. So the way to refresh a stale branch is to merge the base into it, and a branch that has already diverged can be recovered by merging the remote ref back in, which makes the remote tip an ancestor and the push a fast-forward.

That is how #8 was landed: Renovate's commit is preserved in the history rather than rewritten.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added branch-management guidance covering force-push restrictions, merge-based updates, and replacement branches when recovery is not possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->