### PR TITLE
docs: record how to tell a CodeRabbit review actually happened

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,14 +163,20 @@ Two related traps on a long-open bot pull request:
 
 - **CodeRabbit reviews incrementally** and will not re-review a commit it has
   already seen, so a plain `@coderabbitai review` after a push covers only what
-  is new. Use `@coderabbitai full review` to force the whole diff to be read
-  again, which is what a stale base or a rewritten branch needs.
+  is new. `@coderabbitai full review` re-reads the whole current diff, which is
+  what previously reviewed commits or a rewritten history need.
 - **GitHub can leave the base pinned where the bot opened it.** #8 sat 18
   commits behind and GitHub compared against that old base, showing 31 files
-  instead of 7, so CodeRabbit reviewed code already merged to `main`. Merging
-  `main` into the branch corrected the base and the diff. Worth checking with
+  instead of 7, so CodeRabbit reviewed code already merged to `main`. Check with
   `gh pr diff <n> --name-only` before trusting a review: if files appear that
   the branch never touched, the base is stale.
+
+  `full review` does **not** fix that. It re-reads the current diff, and a stale
+  base is what makes the current diff wrong, so a full review of a bad range is
+  still a review of the wrong code. Correct the range first by merging the
+  intended base branch into the pull request branch, confirm with
+  `gh pr diff <n> --name-only` that only the expected files remain, and only
+  then ask for a review. That is the order #8 was recovered in.
 
 That accident was useful once, because reviewing already-merged code surfaced
 five real defects in it, including the passkey quoting bug fixed in #23. It is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,56 @@ becomes an ancestor again, then push normally. `renovate/alpine-3.x` was
 recovered exactly that way in #8. When neither is possible, push a new branch
 and supersede the old pull request.
 
+### Knowing whether CodeRabbit has actually reviewed a branch
+
+Three separate signals look like "reviewed" and are not. Each of these cost
+real time before being pinned down, so check the combination, not any one:
+
+- **A green CodeRabbit check is not a review.** It is green on a skipped draft
+  and on a rate-limited decline. While a review is running the check reads
+  `Review in progress`, which is `pending`, not a conclusion.
+- **Comment timestamps do not move with the review.** CodeRabbit edits its
+  verdict comment in place, so `created_at` stays at the first review forever
+  while `updated_at` moves for unrelated edits. Every timestamp comparison
+  built on this reported fresh reviews as stale.
+- **A SHA appearing in a CodeRabbit comment is not a finished review of that
+  SHA.** The walkthrough comment names the head commit as soon as the review
+  starts, so matching the head against comment bodies reports completion
+  immediately, before anything has been read.
+
+The reliable test is both halves together: the CodeRabbit **check has
+concluded** (not `pending`), *and* the head SHA is named in its comments, which
+is what proves the conclusion refers to the current head rather than an earlier
+one. Then count unresolved review threads.
+
+Also: a **resolved** thread does not mean a fix was verified. CodeRabbit
+auto-resolves threads whose lines a later commit changed, which means the code
+moved, not that it was re-read.
+
+### Dependency-bot pull requests are not reviewed automatically
+
+CodeRabbit does not auto-review pull requests authored by a bot, and posts no
+check on them at all. That is fine while the pull request is only the bot's
+one-line version bump. It stops being fine the moment work is added on top:
+Renovate's Alpine 3.24 bump grew three re-resolved apk pins and a format
+compatibility investigation, and none of it would have been reviewed. Ask for
+it explicitly with an `@coderabbitai review` comment.
+
+Two related traps on a long-open bot pull request:
+
+- **CodeRabbit reviews incrementally** and will not re-review a commit it has
+  already seen, so a review request after a push covers only what is new.
+- **GitHub can leave the base pinned where the bot opened it.** #8 sat 18
+  commits behind and GitHub compared against that old base, showing 31 files
+  instead of 7, so CodeRabbit reviewed code already merged to `main`. Merging
+  `main` into the branch corrected the base and the diff. Worth checking with
+  `gh pr diff <n> --name-only` before trusting a review: if files appear that
+  the branch never touched, the base is stale.
+
+That accident was useful once, because reviewing already-merged code surfaced
+five real defects in it, including the passkey quoting bug fixed in #23. It is
+not a review strategy: nothing guarantees the stale range covers anything.
+
 ### Selectors match the library's templates
 
 Both selectors that once deviated no longer do, as of `rev: v2.2.0`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,21 @@ real time before being pinned down, so check the combination, not any one:
   starts, so matching the head against comment bodies reports completion
   immediately, before anything has been read.
 
-The reliable test is both halves together: the CodeRabbit **check has
-concluded** (not `pending`), *and* the head SHA is named in its comments, which
-is what proves the conclusion refers to the current head rather than an earlier
-one. Then count unresolved review threads.
+The reliable test is both halves together, and the first half has to name the
+conclusion rather than merely require one. `gh pr checks <n> --json
+name,bucket,description` reports `bucket: pass` for a completed review *and*
+for a skipped draft, so the bucket alone cannot tell them apart. The
+`description` is what distinguishes them:
+
+| `bucket`  | `description`                        | Reviewed?         |
+| --------- | ------------------------------------ | ----------------- |
+| `pending` | `Review in progress`                 | no, still running |
+| `pass`    | `Review skipped: draft pull request` | no, never started |
+| `pass`    | `Review completed`                   | yes               |
+
+So: `description` is `Review completed`, *and* the head SHA is named in
+CodeRabbit's comments, which is what proves that completion refers to the
+current head rather than an earlier one. Then count unresolved review threads.
 
 Also: a **resolved** thread does not mean a fix was verified. CodeRabbit
 auto-resolves threads whose lines a later commit changed, which means the code
@@ -151,7 +162,9 @@ it explicitly with an `@coderabbitai review` comment.
 Two related traps on a long-open bot pull request:
 
 - **CodeRabbit reviews incrementally** and will not re-review a commit it has
-  already seen, so a review request after a push covers only what is new.
+  already seen, so a plain `@coderabbitai review` after a push covers only what
+  is new. Use `@coderabbitai full review` to force the whole diff to be read
+  again, which is what a stale base or a rewritten branch needs.
 - **GitHub can leave the base pinned where the bot opened it.** #8 sat 18
   commits behind and GitHub compared against that old base, showing 31 files
   instead of 7, so CodeRabbit reviewed code already merged to `main`. Merging

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -318,8 +318,11 @@ Worth knowing when judging whether a pull request is really reviewed:
 - A **resolved** thread does not mean a fix was verified. CodeRabbit
   auto-resolves threads whose lines a later commit changed, which means the
   code moved, not that it was re-read.
-- The reliable signal is comparing CodeRabbit's latest review timestamp
-  against the head commit's timestamp.
+- **Timestamps cannot answer this**, which this file used to claim they could.
+  CodeRabbit edits its verdict comment in place, so `created_at` stays at the
+  first review while `updated_at` moves for unrelated edits. See "Knowing
+  whether CodeRabbit has actually reviewed a branch" in `CLAUDE.md` for the
+  test that does work.
 
 `drafts: false` is deliberate and stays. CodeRabbit is a GitHub App posting a
 check, not a workflow job, so it cannot be ordered after the pre-commit job


### PR DESCRIPTION
Two `CLAUDE.md` sections, both written from failures during this adoption rather than from documentation.

## Three signals that look like "reviewed" and are not

Each of these produced a wrong conclusion during the adoption:

| Signal | Why it lies |
|---|---|
| Green CodeRabbit check | Green on a skipped draft and on a rate-limited decline; reads `pending` while the review runs |
| Comment timestamps | The verdict comment is **edited in place**, so `created_at` never moves and `updated_at` moves for unrelated edits |
| Head SHA in a comment | The walkthrough comment names the head **as soon as the review starts** |

The timestamp one caused a report that reviews had been dropped when three PRs had been sitting reviewed and clean. The SHA one reported #23 clean while the check still read `Review in progress`, which would have merged an unreviewed pull request.

The reliable test is both halves: **check concluded** *and* **head SHA named**. Then count unresolved threads.

## Bot pull requests are not reviewed at all

CodeRabbit posts no check on a bot-authored PR. Fine for a one-line bump; not fine once work is added on top, which is what happened to #8. Plus the two traps on a long-open bot branch: incremental review skips already-seen commits, and GitHub can leave the base pinned where the bot opened it, showing 31 files instead of 7.

Documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that a full review re-reads the current diff, including earlier commits and rewritten history.
  * Added guidance for correcting a stale base before requesting a review.
  * Documented how to verify the resulting file list before reviewing.
  * Updated review-status guidance to explain that comment timestamps may be unreliable because comments can be edited in place.
  * Added a reference to the recommended review-verification procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->