### PR TITLE
fix: quote Makefile script arguments, resolve docker by path, prohibit AI attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,3 +234,7 @@ some disk, and is removed automatically if unchanged.
 - No `|| true` in Makefile; use `docker inspect` conditionals instead
 - `make clean` uses `docker inspect` pre-checks before `rm` to avoid false failures
 - Do not add `|| true` as a general error suppressor; fail explicitly with a clear message
+- Never add `Co-Authored-By: Claude`, "Generated with Claude Code", or any
+  other AI attribution to a commit message, a pull request body, or a
+  changelog entry. This is a hard prohibition, not a preference: it applies
+  to every commit and every pull request, with no exception.

--- a/Makefile
+++ b/Makefile
@@ -182,15 +182,15 @@ backup:
 		/app/backup.sh \
 			"/backup/src" \
 			"/backup/enc" \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/backup/passfile" \
-			${REMOTE_SERVER} \
+			"${REMOTE_SERVER}" \
 			"/backup/brave-filter-rules.txt" \
-			${RSYNC_RATE_LIMIT} \
-			${RSYNC_LOOP} \
-			${GOCRYPTFS_CIPHER} \
-			${GOCRYPTFS_SCRYPT_N} \
-			${GOCRYPTFS_ENCRYPT_NAMES}
+			"${RSYNC_RATE_LIMIT}" \
+			"${RSYNC_LOOP}" \
+			"${GOCRYPTFS_CIPHER}" \
+			"${GOCRYPTFS_SCRYPT_N}" \
+			"${GOCRYPTFS_ENCRYPT_NAMES}"
 
 backup_as_root:
 	@$(call _passkey_check,/backup/passfile); \
@@ -217,15 +217,15 @@ backup_as_root:
 		/app/backup.sh \
 			"/backup/src" \
 			"/backup/enc" \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/backup/passfile" \
-			${REMOTE_SERVER} \
+			"${REMOTE_SERVER}" \
 			"/backup/brave-filter-rules.txt" \
-			${RSYNC_RATE_LIMIT} \
-			${RSYNC_LOOP} \
-			${GOCRYPTFS_CIPHER} \
-			${GOCRYPTFS_SCRYPT_N} \
-			${GOCRYPTFS_ENCRYPT_NAMES}
+			"${RSYNC_RATE_LIMIT}" \
+			"${RSYNC_LOOP}" \
+			"${GOCRYPTFS_CIPHER}" \
+			"${GOCRYPTFS_SCRYPT_N}" \
+			"${GOCRYPTFS_ENCRYPT_NAMES}"
 
 # Restore user backup to a staging directory (safe, review before moving)
 restore:
@@ -248,14 +248,14 @@ restore:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			${REMOTE_SERVER} \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER}" \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			${RSYNC_RATE_LIMIT} \
-			${RSYNC_LOOP} \
+			"${RSYNC_RATE_LIMIT}" \
+			"${RSYNC_LOOP}" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -280,14 +280,14 @@ restore_to_origin:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			${REMOTE_SERVER} \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER}" \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			${RSYNC_RATE_LIMIT} \
-			${RSYNC_LOOP} \
+			"${RSYNC_RATE_LIMIT}" \
+			"${RSYNC_LOOP}" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -312,14 +312,14 @@ restore_as_root:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			${REMOTE_SERVER} \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER}" \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			${RSYNC_RATE_LIMIT} \
-			${RSYNC_LOOP} \
+			"${RSYNC_RATE_LIMIT}" \
+			"${RSYNC_LOOP}" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -348,14 +348,14 @@ restore_as_root_to_origin:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			${REMOTE_SERVER} \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER}" \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			${RSYNC_RATE_LIMIT} \
-			${RSYNC_LOOP} \
+			"${RSYNC_RATE_LIMIT}" \
+			"${RSYNC_LOOP}" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -379,8 +379,8 @@ view:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/view.sh \
-			${REMOTE_SERVER} \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER}" \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/gocrypt-view/passfile" \
 			"/gocrypt-view/encrypted" \
 			"/gocrypt-view/decrypted"
@@ -405,8 +405,8 @@ view_as_root:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/view.sh \
-			${REMOTE_SERVER} \
-			${REMOTE_SERVER_BACKUP_FOLDER} \
+			"${REMOTE_SERVER}" \
+			"${REMOTE_SERVER_BACKUP_FOLDER}" \
 			"/gocrypt-view/passfile" \
 			"/gocrypt-view/encrypted" \
 			"/gocrypt-view/decrypted"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -357,7 +357,9 @@ waiting. Recovery needs a manual `@coderabbitai review`.
 
 **Still open, and not fixable by config:** CodeRabbit's included-review quota
 **drops** a review rather than queueing it. A push arriving while the quota is
-exhausted is declined and never retried.
+exhausted is declined, and CodeRabbit does not retry it automatically; its
+decline comment does name when the quota resets and invites a manual
+re-request, so recovery is a deliberate step rather than a wait.
 
 The quota is plan-specific and rolling rather than a documented constant, so
 take the figure from CodeRabbit itself rather than from here: on 2026-08-18 it

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -235,12 +235,16 @@ into it would make both harder to review.
 
 ### 8. `tests/conftest.py` invokes `docker` by bare name
 
-**Status:** open, low priority. Also raised on the formatting pull request.
+**Status:** fixed. A module-level `DOCKER = shutil.which("docker")` is
+resolved once at import time, and every call site (`docker_rm`,
+`require_docker`, and each `subprocess`/`run` invocation building or
+inspecting a container) reuses that resolved path instead of the literal
+string `docker`.
 
-Every Docker call passes the literal string `docker` to `subprocess.run`, so
-resolution depends on whatever `PATH` the suite inherits. Resolving it once
+Every Docker call passed the literal string `docker` to `subprocess.run`, so
+resolution depended on whatever `PATH` the suite inherited. Resolving it once
 with `shutil.which` (the suite already imports `shutil` for its
-`require_docker` check) and reusing that path would remove the ambiguity.
+`require_docker` check) and reusing that path removes the ambiguity.
 
 Low priority because the suite already refuses to run when `shutil.which`
 cannot find Docker, so the realistic failure is a surprising binary rather

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -287,6 +287,14 @@ behaviour change to a documented option, so it wants its own pull request.
 
 ### 10. The Makefile expands env variables unquoted into positional arguments
 
+**Status:** fixed. Every `${VAR}` expansion is now quoted at all eight call
+sites that pass positional arguments to `backup.sh`, `restore.sh` and
+`view.sh` (two, four and two respectively). `tests/test_makefile.py` blanks
+`REMOTE_SERVER` and `GOCRYPTFS_CIPHER` in turn and drives `make --dry-run`
+against each script, asserting both the argument count and the value in
+every slot, so a blank value can no longer shift the arguments; the tests
+were confirmed to fail against the unquoted Makefile before the fix.
+
 Found while fixing item 9, and more dangerous than item 9 was.
 
 `backup.sh` and its siblings take their configuration as positional arguments,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,13 @@ PASSPHRASE = "integration-test-passphrase"
 # mount and the tests mount repeatedly. It does not change what is exercised.
 SCRYPT_N = 10
 
+# Resolved once at import time and reused at every call site, so every Docker
+# invocation in the suite runs the same binary instead of each one resolving
+# the bare name "docker" against PATH separately. None (rather than falling
+# back to the string "docker") is deliberate: it is what lets require_docker
+# below actually detect a missing binary instead of masking it.
+DOCKER = shutil.which("docker")
+
 
 def run(cmd, **kwargs):
     """Run a command and return the CompletedProcess, capturing output."""
@@ -79,16 +86,16 @@ def run_make(target, env_file, timeout=900, extra_args=()):
 
 def docker_rm(name):
     """Remove a container if it exists, without relying on error suppression."""
-    exists = run(["docker", "inspect", "--type", "container", name])
+    exists = run([DOCKER, "inspect", "--type", "container", name])
     if exists.returncode == 0:
-        run(["docker", "rm", "--force", name])
+        run([DOCKER, "rm", "--force", name])
 
 
 @pytest.fixture(scope="session", autouse=True)
 def require_docker():
-    if shutil.which("docker") is None:
+    if DOCKER is None:
         pytest.skip("docker is not installed")
-    info = run(["docker", "info"])
+    info = run([DOCKER, "info"])
     if info.returncode != 0:
         pytest.skip("docker daemon is not reachable")
 
@@ -209,7 +216,7 @@ exec /usr/sbin/sshd -D -e -o PermitRootLogin=yes
 """
     started = run(
         [
-            "docker",
+            DOCKER,
             "run",
             "--detach",
             "--name",
@@ -238,7 +245,7 @@ exec /usr/sbin/sshd -D -e -o PermitRootLogin=yes
 def _wait_for_ip(attempts=30):
     fmt = "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}"
     for _ in range(attempts):
-        result = run(["docker", "inspect", "-f", fmt, REMOTE_CONTAINER])
+        result = run([DOCKER, "inspect", "-f", fmt, REMOTE_CONTAINER])
         address = result.stdout.strip()
         if address:
             return address
@@ -251,7 +258,7 @@ def _wait_for_sshd(address, known_hosts, attempts=30):
     for _ in range(attempts):
         scan = run(
             [
-                "docker",
+                DOCKER,
                 "run",
                 "--rm",
                 "--entrypoint",
@@ -303,7 +310,7 @@ def initialised_source(image, workspace):
         )
         result = run(
             [
-                "docker",
+                DOCKER,
                 "run",
                 "--rm",
                 "--user",
@@ -337,7 +344,7 @@ def _chown_to_container_root(paths):
         volumes += ["--volume", f"{path}:/chown/{index}"]
     result = run(
         [
-            "docker",
+            DOCKER,
             "run",
             "--rm",
             "--user",
@@ -405,7 +412,7 @@ def remote_listing():
     """
     result = run(
         [
-            "docker",
+            DOCKER,
             "exec",
             REMOTE_CONTAINER,
             "find",
@@ -431,7 +438,7 @@ def remote_manifest():
     """
     result = run(
         [
-            "docker",
+            DOCKER,
             "exec",
             REMOTE_CONTAINER,
             "sh",
@@ -452,7 +459,7 @@ def remote_bytes(relative_path):
     """Raw bytes of a file on the remote, as stored (encrypted)."""
     result = subprocess.run(
         [
-            "docker",
+            DOCKER,
             "exec",
             REMOTE_CONTAINER,
             "cat",

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -5,7 +5,119 @@ These need neither Docker nor a remote, so they stay fast and run first.
 
 from __future__ import annotations
 
-from conftest import REPO_ROOT, run
+import shlex
+
+import pytest
+from conftest import REPO_ROOT, _read_var, run
+
+# Positional argument specs for the three scripts the Makefile invokes,
+# in call order. "literal" entries are fixed container paths the Makefile
+# hardcodes; "var" entries are ${VAR} expansions read from the env file.
+# Mirrors the __N parameters each script documents in its own "# parameters"
+# block (scripts/backup.sh, scripts/restore.sh, scripts/view.sh).
+_BACKUP_ARGS = (
+    ("literal", "/backup/src"),
+    ("literal", "/backup/enc"),
+    ("var", "REMOTE_SERVER_BACKUP_FOLDER"),
+    ("literal", "/backup/passfile"),
+    ("var", "REMOTE_SERVER"),
+    ("literal", "/backup/brave-filter-rules.txt"),
+    ("var", "RSYNC_RATE_LIMIT"),
+    ("var", "RSYNC_LOOP"),
+    ("var", "GOCRYPTFS_CIPHER"),
+    ("var", "GOCRYPTFS_SCRYPT_N"),
+    ("var", "GOCRYPTFS_ENCRYPT_NAMES"),
+)
+
+_RESTORE_ARGS = (
+    ("var", "REMOTE_SERVER"),
+    ("var", "REMOTE_SERVER_BACKUP_FOLDER"),
+    ("literal", "/restore/enc"),
+    ("literal", "/restore/dec"),
+    ("literal", "/restore/passfile"),
+    ("literal", "/restore/restore-exclude-list.txt"),
+    ("var", "RSYNC_RATE_LIMIT"),
+    ("var", "RSYNC_LOOP"),
+    ("literal", "/restore/origin"),
+    ("literal", "/restore/restore-paths.txt"),
+)
+
+_VIEW_ARGS = (
+    ("var", "REMOTE_SERVER"),
+    ("var", "REMOTE_SERVER_BACKUP_FOLDER"),
+    ("literal", "/gocrypt-view/passfile"),
+    ("literal", "/gocrypt-view/encrypted"),
+    ("literal", "/gocrypt-view/decrypted"),
+)
+
+
+def _env_file_with_overrides(tmp_path, overrides):
+    """A full env file derived from .env.example with some values replaced.
+
+    Starting from .env.example rather than a minimal hand-built file means
+    every variable the Makefile reads has a realistic value, so only the
+    variable under test differs from an ordinary run. Override values are
+    written exactly as given, unquoted, which is itself a valid way to set a
+    path-like value in an env file and keeps a space in the override real
+    rather than absorbed by a pair of literal quote characters.
+    """
+    example = (REPO_ROOT / ".env.example").read_text()
+    lines = []
+    remaining = dict(overrides)
+    for line in example.splitlines():
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key = line.split("=", 1)[0]
+        if key in remaining:
+            lines.append(f"{key}={remaining.pop(key)}")
+        else:
+            lines.append(line)
+    assert not remaining, f"override keys not found in .env.example: {remaining}"
+    path = tmp_path / "env.override"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _expected_value(spec_item, overrides, example_text):
+    """The value a spec entry should resolve to, given the overrides in play."""
+    kind, name = spec_item
+    if kind == "literal":
+        return name
+    if name in overrides:
+        return overrides[name].strip('"')
+    return _read_var(example_text, name)
+
+
+def _dry_run_positional_args(target, env_file, script_name):
+    """The shell-parsed positional arguments 'make --dry-run' would pass.
+
+    'make --dry-run' echoes the recipe's shell text after ${VAR} expansion,
+    embedded newlines and all, since the backslash line continuations make
+    the whole recipe one logical shell command. Joining the lines from the
+    script invocation onward, stopping at the first line that does not end
+    in a continuing backslash, and handing the result to shlex reproduces
+    exactly what the shell would see, quote characters included. This is
+    the same target 'make --dry-run' the maintainer used to confirm the fix
+    by hand before writing this helper.
+    """
+    result = run(["make", "--dry-run", target, f"ENV_FILE={env_file}"])
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    lines = result.stdout.splitlines()
+    start = next(
+        i
+        for i, line in enumerate(lines)
+        if line.strip().startswith(f"/app/{script_name}")
+    )
+    logical = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        continued = stripped.endswith("\\")
+        logical.append(stripped[:-1].strip() if continued else stripped)
+        if not continued:
+            break
+    tokens = shlex.split(" ".join(logical))
+    return tokens[1:]  # drop the script path itself
 
 
 def test_help_is_the_default_goal():
@@ -87,3 +199,65 @@ def test_no_blanket_error_suppression_in_the_makefile():
         if "|| true" in line
     ]
     assert not offenders, f"'|| true' found in the Makefile: {offenders}"
+
+
+@pytest.mark.parametrize(
+    ("target", "script_name", "arg_spec"),
+    [
+        ("backup", "backup.sh", _BACKUP_ARGS),
+        ("restore", "restore.sh", _RESTORE_ARGS),
+        ("view", "view.sh", _VIEW_ARGS),
+    ],
+)
+def test_blank_env_var_does_not_shift_script_arguments(
+    tmp_path, target, script_name, arg_spec
+):
+    """docs/TODO.md item 10: a blank ${VAR} expansion must arrive as an empty
+    positional argument, not vanish and shift every later argument down one
+    slot. REMOTE_SERVER is used here because it is passed to all three
+    scripts, so the same check covers backup.sh, restore.sh and view.sh.
+    """
+    example_text = (REPO_ROOT / ".env.example").read_text()
+    overrides = {"REMOTE_SERVER": ""}
+    env_file = _env_file_with_overrides(tmp_path, overrides)
+
+    args = _dry_run_positional_args(target, env_file, script_name)
+    expected = [_expected_value(item, overrides, example_text) for item in arg_spec]
+    assert args == expected
+
+
+def test_blank_gocryptfs_cipher_does_not_flip_encrypt_names_default(tmp_path):
+    """The exact scenario docs/TODO.md item 10 and CLAUDE.md's gotcha
+    describe: blanking GOCRYPTFS_CIPHER must not shift GOCRYPTFS_SCRYPT_N
+    into the cipher slot and push GOCRYPTFS_ENCRYPT_NAMES out of the argument
+    list entirely, which previously made backup.sh fall back to its 'true'
+    default and silently defeat every rsync filter rule (CLAUDE.md:
+    GOCRYPTFS_ENCRYPT_NAMES must be false for filter rules to match).
+    """
+    example_text = (REPO_ROOT / ".env.example").read_text()
+    overrides = {"GOCRYPTFS_CIPHER": ""}
+    env_file = _env_file_with_overrides(tmp_path, overrides)
+
+    args = _dry_run_positional_args("backup", env_file, "backup.sh")
+    expected = [_expected_value(item, overrides, example_text) for item in _BACKUP_ARGS]
+    assert args == expected
+
+    assert args[8] == ""  # GOCRYPTFS_CIPHER: quoted-and-empty, not vanished
+    assert args[9] == _read_var(example_text, "GOCRYPTFS_SCRYPT_N")
+    assert args[10] == _read_var(example_text, "GOCRYPTFS_ENCRYPT_NAMES")
+
+
+def test_value_with_a_space_does_not_split_into_two_arguments(tmp_path):
+    """Same defect, opposite direction: an unquoted expansion whose value
+    contains a space splits into two shell words instead of shifting later
+    arguments down, which is the same class of bug docs/TODO.md item 10
+    names for REMOTE_SERVER and REMOTE_SERVER_BACKUP_FOLDER.
+    """
+    example_text = (REPO_ROOT / ".env.example").read_text()
+    overrides = {"REMOTE_SERVER_BACKUP_FOLDER": "/mnt/backups/a user"}
+    env_file = _env_file_with_overrides(tmp_path, overrides)
+
+    args = _dry_run_positional_args("view", env_file, "view.sh")
+    expected = [_expected_value(item, overrides, example_text) for item in _VIEW_ARGS]
+    assert args == expected
+    assert args[1] == "/mnt/backups/a user"


### PR DESCRIPTION
## Summary

- Quote every `${VAR}` expansion at the eight Makefile call sites that pass positional arguments to `backup.sh`, `restore.sh` and `view.sh` (docs/TODO.md item 10). Unquoted, a blank value disappears instead of arriving as an empty argument, shifting every later argument down one slot; blanking `GOCRYPTFS_CIPHER` pushed `GOCRYPTFS_ENCRYPT_NAMES` out of the argument list entirely, falling back to `true` and silently defeating every rsync filter rule. `tests/test_makefile.py` now drives `make --dry-run` against each script with a blank value and asserts the full argument list.
- Resolve `docker` once via `shutil.which` in `tests/conftest.py` and reuse that path at every call site instead of the literal string `"docker"` (docs/TODO.md item 8).
- Add a hard rule to `CLAUDE.md` prohibiting AI attribution (`Co-Authored-By: Claude`, "Generated with Claude Code", etc.) in commits, PR bodies or changelog entries, and correct `docs/TODO.md`'s claim that a rate-limited CodeRabbit review is "declined and never retried" (it names the reset time and invites a manual re-request).
- Mark items 8 and 10 in `docs/TODO.md` resolved, following the convention item 9 already uses.

## Test plan

- [x] `pytest tests/ -k "not roundtrip and not build"`: 30 passed (Docker was available in this environment, so these ran for real rather than skipping).
- [x] Confirmed the new Makefile-argument tests FAIL against the unquoted (pre-fix) Makefile, and PASS after restoring the fix.
- [x] `pre-commit run --all-files`: all hooks pass.
- [x] Verified all 8 call sites (2x `backup.sh`, 4x `restore.sh`, 2x `view.sh`) are quoted; the restore shorthand aliases near line 109 have no `${VAR}` expansions to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup, restore, and view commands so configuration values containing spaces or blank values are passed correctly.
  * Prevented empty settings from shifting command arguments or changing encryption behavior unexpectedly.
  * Improved handling when Docker is unavailable, allowing related checks to be skipped cleanly.

* **Documentation**
  * Updated project documentation to reflect completed fixes and clarify review-related procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->