### PR TITLE
docs: record that quoting cannot protect a quoted env value with a space

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -77,6 +77,7 @@
     "nosyslog",
     "nounset",
     "passfile",
+    "patsubst",
     "Pinatti",
     "pipefail",
     "rootdir",

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -379,11 +379,12 @@ actually guaranteed today rather than what would be nice.
 Two candidate fixes, neither started:
 
 - Strip the surrounding quotes in the Makefile. `$(patsubst "%",%,$(VAR))` does
-  **not** work: make's text functions split on whitespace, so a value with a
-  space is two words and neither matches the pattern. `$(subst ",,$(VAR))` does
-  work, verified on a value with a space, a value without one, and an empty
-  value, but it removes every double quote in the value rather than only a
-  surrounding pair.
+  **not** work: `patsubst` operates on whitespace-separated words, so a value
+  with a space arrives as two words, neither of which matches the pattern.
+  `$(subst ",,$(VAR))` does work, because it is a literal text replacement and
+  does not tokenise its input at all. Verified on a value with a space, a value
+  without one, and an empty value. Its cost is that it removes every double
+  quote in the value rather than only a surrounding pair.
 - Drop the quoting convention from `.env.example` and let `dotenv-linter`'s
   `QuoteCharacter` check enforce it, which would retire the local-hook
   workaround as a side effect. This changes a documented contract and every

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -341,6 +341,54 @@ invokes a script this way. Quoted and empty is correct: the scripts use
 a missing one. Left for its own pull request because it touches several targets
 and deserves a test that a blank env variable cannot shift anything.
 
+### 11. Quoting cannot protect a value whose env-file entry carries its own quotes
+
+**Status:** open, low priority. Found while verifying item 10's fix. It is the
+half of item 10 that quoting does not reach.
+
+`.env.example` quotes every value deliberately. `CLAUDE.md` records that
+convention as the reason `dotenv-linter` runs as a local hook: its 16
+`QuoteCharacter` findings are expected and suppressed. `include $(ENV_FILE)`
+hands the make variable those quote characters as part of its value, so
+`REMOTE_SERVER_BACKUP_FOLDER="/mnt/my backups"` sets the variable to
+`"/mnt/my backups"`, quotes included.
+
+Item 10 wrapped every expansion in a second pair, which produces
+`""/mnt/my backups""`. The two pairs do not nest. The shell concatenates an
+empty string, the bare word, and another empty string, then splits on the
+space exactly as before. Verified against the merged fix with
+`make --dry-run backup` and an env file holding a path with a space:
+
+```text
+/app/backup.sh \
+        "/backup/src" \
+        "/backup/enc" \
+        ""/mnt/my backups"" \
+```
+
+What item 10 did close, under both conventions, is the shifting. A blank
+`GOCRYPTFS_CIPHER` now emits `""""`, which is one empty argument, so
+`GOCRYPTFS_ENCRYPT_NAMES` keeps the eleventh slot and its `false` value. That
+was the dangerous half. What remains is the space case alone, and only for
+values the env file quotes, which is every value in `.env.example`.
+
+`tests/test_makefile.py` asserts the space case with an unquoted override
+rather than the quoted convention. That is deliberate: it tests what is
+actually guaranteed today rather than what would be nice.
+
+Two candidate fixes, neither started:
+
+- Strip the surrounding quotes in the Makefile. `$(patsubst "%",%,$(VAR))` does
+  **not** work: make's text functions split on whitespace, so a value with a
+  space is two words and neither matches the pattern. `$(subst ",,$(VAR))` does
+  work, verified on a value with a space, a value without one, and an empty
+  value, but it removes every double quote in the value rather than only a
+  surrounding pair.
+- Drop the quoting convention from `.env.example` and let `dotenv-linter`'s
+  `QuoteCharacter` check enforce it, which would retire the local-hook
+  workaround as a side effect. This changes a documented contract and every
+  existing `.env` file, so it is the larger of the two.
+
 ## CodeRabbit: automatic reviews stop silently on a busy branch
 
 `.coderabbit.yaml` now sets `reviews.auto_review.auto_pause_after_reviewed_commits: 0`.


### PR DESCRIPTION
Follow-up to #26, which closed `docs/TODO.md` item 10.

Verifying that fix showed one half of the problem survives it. `.env.example`
quotes every value deliberately, `include $(ENV_FILE)` hands those quote
characters to the make variable, and the recipe's own quotes do not nest with
them, so a path containing a space still splits into two arguments.

The dangerous half is genuinely closed: a blank value now emits `""""`, one
empty argument, so nothing shifts and `GOCRYPTFS_ENCRYPT_NAMES` keeps its
slot under both env-file conventions.

Recorded as item 11 with the reproduction, rather than fixed here, because
both candidate fixes touch the env-file contract. The note says which of them
works: `$(patsubst "%",%,$(VAR))` does not, since make's text functions
split on whitespace and a value with a space is two words that match no
pattern, while `$(subst ",,$(VAR))` does, verified against a value with a
space, one without, and an empty value.

`patsubst` joins the make identifiers already in `.cspell.json`'s ignore
list, next to `endef` and `MAKECMDGOALS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a TODO documenting a remaining Makefile quoting limitation for environment-file values containing embedded quotes.
  - Recorded verified behavior, existing coverage, and potential future fixes.

- **Chores**
  - Updated spelling-check configuration to recognize an additional Makefile-related term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->