### PR TITLE
fix: strip literal quotes from quoted env values before Makefile quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,15 +182,15 @@ backup:
 		/app/backup.sh \
 			"/backup/src" \
 			"/backup/enc" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/backup/passfile" \
-			"${REMOTE_SERVER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
 			"/backup/brave-filter-rules.txt" \
-			"${RSYNC_RATE_LIMIT}" \
-			"${RSYNC_LOOP}" \
-			"${GOCRYPTFS_CIPHER}" \
-			"${GOCRYPTFS_SCRYPT_N}" \
-			"${GOCRYPTFS_ENCRYPT_NAMES}"
+			"$(subst ",,${RSYNC_RATE_LIMIT})" \
+			"$(subst ",,${RSYNC_LOOP})" \
+			"$(subst ",,${GOCRYPTFS_CIPHER})" \
+			"$(subst ",,${GOCRYPTFS_SCRYPT_N})" \
+			"$(subst ",,${GOCRYPTFS_ENCRYPT_NAMES})"
 
 backup_as_root:
 	@$(call _passkey_check,/backup/passfile); \
@@ -217,15 +217,15 @@ backup_as_root:
 		/app/backup.sh \
 			"/backup/src" \
 			"/backup/enc" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/backup/passfile" \
-			"${REMOTE_SERVER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
 			"/backup/brave-filter-rules.txt" \
-			"${RSYNC_RATE_LIMIT}" \
-			"${RSYNC_LOOP}" \
-			"${GOCRYPTFS_CIPHER}" \
-			"${GOCRYPTFS_SCRYPT_N}" \
-			"${GOCRYPTFS_ENCRYPT_NAMES}"
+			"$(subst ",,${RSYNC_RATE_LIMIT})" \
+			"$(subst ",,${RSYNC_LOOP})" \
+			"$(subst ",,${GOCRYPTFS_CIPHER})" \
+			"$(subst ",,${GOCRYPTFS_SCRYPT_N})" \
+			"$(subst ",,${GOCRYPTFS_ENCRYPT_NAMES})"
 
 # Restore user backup to a staging directory (safe, review before moving)
 restore:
@@ -248,14 +248,14 @@ restore:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			"${REMOTE_SERVER}" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			"${RSYNC_RATE_LIMIT}" \
-			"${RSYNC_LOOP}" \
+			"$(subst ",,${RSYNC_RATE_LIMIT})" \
+			"$(subst ",,${RSYNC_LOOP})" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -280,14 +280,14 @@ restore_to_origin:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			"${REMOTE_SERVER}" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			"${RSYNC_RATE_LIMIT}" \
-			"${RSYNC_LOOP}" \
+			"$(subst ",,${RSYNC_RATE_LIMIT})" \
+			"$(subst ",,${RSYNC_LOOP})" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -312,14 +312,14 @@ restore_as_root:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			"${REMOTE_SERVER}" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			"${RSYNC_RATE_LIMIT}" \
-			"${RSYNC_LOOP}" \
+			"$(subst ",,${RSYNC_RATE_LIMIT})" \
+			"$(subst ",,${RSYNC_LOOP})" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -348,14 +348,14 @@ restore_as_root_to_origin:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/restore.sh \
-			"${REMOTE_SERVER}" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/restore/enc" \
 			"/restore/dec" \
 			"/restore/passfile" \
 			"/restore/restore-exclude-list.txt" \
-			"${RSYNC_RATE_LIMIT}" \
-			"${RSYNC_LOOP}" \
+			"$(subst ",,${RSYNC_RATE_LIMIT})" \
+			"$(subst ",,${RSYNC_LOOP})" \
 			"/restore/origin" \
 			"/restore/restore-paths.txt"
 
@@ -379,8 +379,8 @@ view:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/view.sh \
-			"${REMOTE_SERVER}" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/gocrypt-view/passfile" \
 			"/gocrypt-view/encrypted" \
 			"/gocrypt-view/decrypted"
@@ -405,8 +405,8 @@ view_as_root:
 		--rm \
 		--interactive --tty ${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
 		/app/view.sh \
-			"${REMOTE_SERVER}" \
-			"${REMOTE_SERVER_BACKUP_FOLDER}" \
+			"$(subst ",,${REMOTE_SERVER})" \
+			"$(subst ",,${REMOTE_SERVER_BACKUP_FOLDER})" \
 			"/gocrypt-view/passfile" \
 			"/gocrypt-view/encrypted" \
 			"/gocrypt-view/decrypted"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -343,8 +343,43 @@ and deserves a test that a blank env variable cannot shift anything.
 
 ### 11. Quoting cannot protect a value whose env-file entry carries its own quotes
 
-**Status:** open, low priority. Found while verifying item 10's fix. It is the
-half of item 10 that quoting does not reach.
+**Status:** fixed. The seven `${VAR}` expansions that actually vary across the
+eight positional-argument call sites (`REMOTE_SERVER_BACKUP_FOLDER`,
+`REMOTE_SERVER`, `RSYNC_RATE_LIMIT`, `RSYNC_LOOP`, `GOCRYPTFS_CIPHER`,
+`GOCRYPTFS_SCRYPT_N`, `GOCRYPTFS_ENCRYPT_NAMES`) are now wrapped as
+`"$(subst ",,${VAR})"` instead of `"${VAR}"`. The recipe strips any literal
+quote characters the env file supplied before the Makefile's own quotes are
+added, so the two pairs no longer fight. `tests/test_makefile.py` adds a
+quoted-value-with-a-space case, run against `backup.sh`, `restore.sh` and
+`view.sh`, plus a quoted-empty-value case for `GOCRYPTFS_CIPHER`; both were
+confirmed to fail against the pre-fix Makefile and pass after.
+
+Deliberately not the ingest-time normalisation this item's own note below
+considered as the preferred shape. `include $(ENV_FILE)` also populates
+variables such as `BACKUP_SOURCE_FOLDER`, `SSH_KEY_FILE` and
+`DOCKER_IMAGE_TAG_NAME`, which are used raw at `--volume`, `--tag`,
+`--build-arg`, `docker rmi` and `rm -f` call sites that item 10 never
+quoted. Under the quoted convention `.env.example` uses, those call sites are
+accidentally already safe: the env file's own quote characters are the only
+quoting the shell sees there, so a value with a space parses as one word
+today, confirmed with `make --dry-run backup` against
+`BACKUP_SOURCE_FOLDER="/home/my user"`, which emits `--volume "/home/my
+user":/backup/src` and parses as a single argument. Stripping those quotes
+at ingest without also adding real quotes at every one of those call sites
+would have regressed that case. None of the seven variables this bug
+actually affects appear at any `--volume` or `--tag` site, so the
+per-call-site fix reaches exactly what needs it without touching the rest of
+the Makefile's quoting at all.
+
+`RESTORE_PATHS` was left alone for a different reason. It reaches
+`docker run` as `--env RESTORE_PATHS='${RESTORE_PATHS}'`, already
+single-quote protected at the Makefile level, so the quote-nesting bug this
+item describes does not apply to it. It is also not one of `.env.example`'s
+documented variables; its supported path is
+`make restore RESTORE_PATHS="Documents/ .config/Code/User/"` on the command
+line, where the shell strips the quotes before `make` ever sees the value.
+
+The original finding, left for the record:
 
 `.env.example` quotes every value deliberately. `CLAUDE.md` records that
 convention as the reason `dotenv-linter` runs as a local hook: its 16

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -351,8 +351,10 @@ eight positional-argument call sites (`REMOTE_SERVER_BACKUP_FOLDER`,
 quote characters the env file supplied before the Makefile's own quotes are
 added, so the two pairs no longer fight. `tests/test_makefile.py` adds a
 quoted-value-with-a-space case, run against `backup.sh`, `restore.sh` and
-`view.sh`, plus a quoted-empty-value case for `GOCRYPTFS_CIPHER`; both were
-confirmed to fail against the pre-fix Makefile and pass after.
+`view.sh`, plus a quoted-empty-value case for `GOCRYPTFS_CIPHER`. Only the
+space case failed against the pre-fix Makefile, which is the bug this item
+describes; the empty case passed before and after, because item 10 already
+guaranteed it, and it is here to keep that guarantee from regressing.
 
 Deliberately not the ingest-time normalisation this item's own note below
 considered as the preferred shape. `include $(ENV_FILE)` also populates

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -261,3 +261,61 @@ def test_value_with_a_space_does_not_split_into_two_arguments(tmp_path):
     expected = [_expected_value(item, overrides, example_text) for item in _VIEW_ARGS]
     assert args == expected
     assert args[1] == "/mnt/backups/a user"
+
+
+@pytest.mark.parametrize(
+    ("target", "script_name", "arg_spec"),
+    [
+        ("backup", "backup.sh", _BACKUP_ARGS),
+        ("restore", "restore.sh", _RESTORE_ARGS),
+        ("view", "view.sh", _VIEW_ARGS),
+    ],
+)
+def test_quoted_env_value_with_a_space_arrives_as_one_argument(
+    tmp_path, target, script_name, arg_spec
+):
+    """docs/TODO.md item 11: .env.example quotes every value deliberately, so
+    'include $(ENV_FILE)' hands the make variable those literal quote
+    characters as part of its value, e.g.
+    REMOTE_SERVER_BACKUP_FOLDER="/mnt/my backups" sets the variable to
+    '"/mnt/my backups"', quotes included. Item 10 wrapped each expansion in a
+    second pair of Makefile-level quotes, but the two pairs do not nest: the
+    recipe used to emit '"/mnt/my backups"' with the quote characters still
+    embedded, and the shell split it into two words on the space exactly as
+    before item 10. This is the case that fails today (before the item 11
+    fix strips the embedded quotes with $(subst)) and is the one item 10
+    left open. REMOTE_SERVER_BACKUP_FOLDER is used because it appears in all
+    three scripts' argument lists, so one override covers backup.sh,
+    restore.sh and view.sh.
+    """
+    example_text = (REPO_ROOT / ".env.example").read_text()
+    overrides = {"REMOTE_SERVER_BACKUP_FOLDER": '"/mnt/backups/a user"'}
+    env_file = _env_file_with_overrides(tmp_path, overrides)
+
+    args = _dry_run_positional_args(target, env_file, script_name)
+    expected = [_expected_value(item, overrides, example_text) for item in arg_spec]
+    assert args == expected
+    assert "/mnt/backups/a user" in args
+
+
+def test_quoted_blank_gocryptfs_cipher_does_not_flip_encrypt_names_default(tmp_path):
+    """The item 10 shifting guarantee re-checked under the quoted convention.
+
+    test_blank_gocryptfs_cipher_does_not_flip_encrypt_names_default already
+    covers an unquoted blank (GOCRYPTFS_CIPHER=). This is the same scenario
+    with GOCRYPTFS_CIPHER="" instead, which is how .env.example's own
+    convention would spell an empty value. docs/TODO.md item 11 records this
+    as one of the three cases $(subst ",,$(VAR)) was verified against: a
+    value with a space, a value without one, and an empty value.
+    """
+    example_text = (REPO_ROOT / ".env.example").read_text()
+    overrides = {"GOCRYPTFS_CIPHER": '""'}
+    env_file = _env_file_with_overrides(tmp_path, overrides)
+
+    args = _dry_run_positional_args("backup", env_file, "backup.sh")
+    expected = [_expected_value(item, overrides, example_text) for item in _BACKUP_ARGS]
+    assert args == expected
+
+    assert args[8] == ""  # GOCRYPTFS_CIPHER: quoted-and-empty, not vanished
+    assert args[9] == _read_var(example_text, "GOCRYPTFS_SCRYPT_N")
+    assert args[10] == _read_var(example_text, "GOCRYPTFS_ENCRYPT_NAMES")


### PR DESCRIPTION
## Summary

- Closes docs/TODO.md item 11: `.env.example` quotes every value, and `include $(ENV_FILE)` hands those literal quote characters into the make variable. Item 10 wrapped each positional-argument expansion in a second pair of quotes, but the two pairs do not nest, so a quoted value with a space (for example `REMOTE_SERVER_BACKUP_FOLDER="/mnt/my backups"`) still split into two shell words.
- Wraps the seven variables that vary across the eight positional-argument call sites (`REMOTE_SERVER_BACKUP_FOLDER`, `REMOTE_SERVER`, `RSYNC_RATE_LIMIT`, `RSYNC_LOOP`, `GOCRYPTFS_CIPHER`, `GOCRYPTFS_SCRYPT_N`, `GOCRYPTFS_ENCRYPT_NAMES`) as `"$(subst ",,${VAR})"` instead of `"${VAR}"`, so the recipe strips any embedded quote characters before adding its own.
- This is a per-call-site fix rather than the ingest-time normalisation the item's note first considered. Ingest-time stripping would also touch variables used raw at `--volume`, `--tag`, `--build-arg`, `docker rmi` and `rm -f` call sites, which today are accidentally protected by the env file's own quote characters under the quoted convention (verified with `make --dry-run backup` against a value with a space). None of the seven variables this bug affects are used at those call sites, so this fix reaches exactly the bug without touching the rest of the Makefile's quoting.
- `RESTORE_PATHS` is untouched: it is already single-quote protected at its `--env` call site and is not one of `.env.example`'s documented variables.
- `docs/TODO.md` item 11 is marked fixed, with the original finding kept below for the record.

## Test plan

- [x] `tests/test_makefile.py` extended with a quoted-value-with-a-space case across `backup.sh`, `restore.sh` and `view.sh`, plus a quoted-empty-value case for `GOCRYPTFS_CIPHER`.
- [x] New tests confirmed to FAIL against the pre-fix Makefile (three space-case failures), then confirmed to PASS after the fix.
- [x] `python -m pytest tests/ -k "not roundtrip and not build"`: 34 passed (Docker was available in this environment; roundtrip/build integration tests deselected per the fast-suite convention).
- [x] `pre-commit run --all-files`: all hooks pass.
- [x] `make --dry-run backup|restore|view` sanity-checked by eye against `.env.example`'s quoted convention and against a value with a space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of quoted configuration values containing spaces during backup, restore, and view operations.
  * Preserved empty encryption settings without shifting or misinterpreting subsequent arguments.
  * Improved reliability when loading values from `.env` configuration files.

* **Tests**
  * Added regression coverage for quoted, space-containing, and empty configuration values across supported operations.

* **Documentation**
  * Updated task documentation to accurately reflect the fix and regression-test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->