### PR TITLE
feat: approve the owner's own pull request once every context is green

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -54,6 +54,7 @@
     "coderabbitai",
     "conftest",
     "datareporting",
+    "dedupe",
     "deprioritised",
     "deprioritises",
     "deprioritized",

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -75,17 +75,26 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
-  # For the owner's own path only, resolved separately below by
-  # `resolve-owner` rather than filtered here the way `pull_request_target`'s
-  # branch and type list is, because a `status` event carries no pull
-  # request context at all to filter on, only a commit SHA. `Review
-  # Verified` is realistically the slowest of the four required contexts,
-  # since it depends on CodeRabbit's own review completing, and
-  # `pull_request_target` alone never fires again once a pull request stops
-  # changing, so without this trigger a pull request whose review finished
-  # after the first poll window closed would need a push it did not
-  # otherwise need, just to get approved.
-  status:
+  # For the owner's own path only. `Review Verified` is realistically the
+  # slowest of the four required contexts, since it depends on CodeRabbit's
+  # own review completing, and `pull_request_target` alone never fires again
+  # once a pull request stops changing, so without a second trigger a pull
+  # request whose review finished after the first poll window closed would
+  # need a push it did not otherwise need, just to get approved.
+  #
+  # `workflow_run`, not `status`: `coderabbit-gate.yml` publishes
+  # `Review Verified` using `secrets.GITHUB_TOKEN`, and GitHub does not start
+  # new workflow runs from events a `GITHUB_TOKEN` creates, specifically to
+  # stop workflows triggering each other in a loop. A `status` trigger here
+  # would never fire from that publish at all, silently, which is a worse
+  # failure than the one it was meant to fix: at least a poll window closing
+  # fails this job closed and logs why. `workflow_run` is exempt from that
+  # restriction because it reacts to the run itself finishing, not to an API
+  # call a token made during it, which is why it exists as the sanctioned
+  # way to chain workflows without a personal access token.
+  workflow_run:
+    workflows: ["CodeRabbit Gate"]
+    types: [completed]
 
 # The floor. Each job widens it for itself.
 permissions:
@@ -295,14 +304,6 @@ jobs:
 
   resolve-owner:
     name: Find the owner's pull request to approve
-    # `status` fires on every commit status this repository receives,
-    # including ones with nothing to do with an owner authored pull request
-    # at all, so this is filtered to the one context whose settling is what
-    # this whole second trigger exists for. `pull_request_target` needs no
-    # such filter: its own type list above already scopes it.
-    if: >-
-      github.event_name != 'status' ||
-      github.event.context == 'Review Verified'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -324,7 +325,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-          STATUS_SHA: ${{ github.event.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -340,17 +340,21 @@ jobs:
               fi
               ;;
 
-            status)
-              # Asked of the API fresh rather than trusted from the payload,
-              # since a `status` event carries only a commit SHA: zero, one,
-              # or in principle more than one open pull request can share a
-              # head SHA, and each is checked against the same author and
-              # fork conditions as the pull_request_target case above.
-              matrix=$(gh api "repos/$REPO/commits/$STATUS_SHA/pulls" \
-                | jq -c '[.[] | select(.state == "open"
-                                  and .user.login == "ivan-pinatti"
-                                  and (.head.repo.fork // false) == false)
-                          | {pr_number: .number}]')
+            workflow_run)
+              # Not narrowed to the one pull request coderabbit-gate.yml
+              # happened to grade in the run that just completed:
+              # `workflow_run.pull_requests` is only populated for the plain
+              # `pull_request` event, and coderabbit-gate.yml never uses it,
+              # so there is nothing reliable to narrow by. Re-checking every
+              # open owner authored pull request instead is cheap, since
+              # this repository only ever has a handful open, and it costs
+              # nothing extra to a pull request that is already approved:
+              # the Approve step below already dedupes.
+              matrix=$(gh pr list --repo "$REPO" --state open --limit 100 \
+                --json number,author,isCrossRepository \
+                --jq '[.[] | select(.author.login == "ivan-pinatti"
+                                and .isCrossRepository == false)
+                        | {pr_number: .number}]')
               ;;
 
             *)
@@ -426,10 +430,11 @@ jobs:
         # A two minute window is still not a guarantee `Review Verified`
         # settles inside it, since it depends on CodeRabbit's own review
         # completing. What makes that survivable rather than a dead end is
-        # the `status` trigger above: this job runs again, and re-reads the
-        # rollup fresh, the moment `Review Verified` actually changes,
-        # rather than depending on this one poll window catching it or on
-        # someone pushing a pull request that has nothing left to change.
+        # the `workflow_run` trigger above: every time coderabbit-gate.yml
+        # finishes a run, this job runs again and re-reads the rollup fresh,
+        # rather than depending on this one poll window catching the change
+        # or on someone pushing a pull request that has nothing left to
+        # change.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -1,7 +1,10 @@
 ---
 name: Bot Auto Merge
 
-# Supplies the approving review that lets a dependency bump merge unattended.
+# Supplies the approving review that lets a dependency bump merge unattended,
+# and, separately, the approving review that lets the repository owner's own
+# pull request enter the merge queue at all.
+#
 # Ported from docker-torrent-box-with-vpn ahead of need, at a time when branch
 # protection was not yet enabled on this repository and every job below was
 # inert. It is not inert any more: branch protection now requires one
@@ -11,7 +14,8 @@ name: Bot Auto Merge
 # Nothing else happens here: the tests are proven by the `Tests` job in
 # pull-request-validation.yml, and the merge itself is GitHub's, armed either
 # by Renovate (platformAutomerge) or by the last step here on the Dependabot
-# path, because Dependabot cannot arm it.
+# path, because Dependabot cannot arm it; the owner's own path arms nothing at
+# all, see the `approve-owner` job below for why.
 #
 # Why an approval has to be supplied at all: no CODEOWNERS file exists here
 # and none should be added for this reason alone, since CODEOWNERS accepts
@@ -19,9 +23,30 @@ name: Bot Auto Merge
 # the plain "require an approving review" rule actually in effect, a
 # dependency bump could not merge without a person or a stored credential
 # belonging to one, because an approving review only counts from an account
-# with write access and this repository has exactly one. If a second write
-# collaborator is ever added, that stops being true and this arrangement has
-# to be revisited.
+# with write access and this repository has exactly one, and GitHub refuses
+# to let that one account approve its own pull request. Confirmed
+# empirically rather than assumed: `gh pr merge --admin` skips the queue
+# entirely (no `merge_group` run at all), and arming auto-merge on an
+# unapproved owner pull request leaves it enqueued forever with no
+# `merge_group` run either, because eligibility to enter the queue needs the
+# approval `enforce_admins: false` does not supply. Today, with exactly one
+# write collaborator, that left the owner a choice between using the queue
+# and merging their own work, never both. The `approve-owner` job below is
+# the fix. If a second write collaborator is ever added, every approval
+# decision in this file has to be revisited: the fence both jobs rely on is
+# that only accounts already trusted with write access are approved here at
+# all, and Renovate, Dependabot and the owner are the only three today.
+#
+# What an `approve-owner` approval does *not* mean: that a human read the
+# diff. It is issued the moment every required context reads green, with no
+# review of the content behind any of it, which is exactly why it is
+# withheld until `Review Verified` itself is green: that context is what
+# actually carries "a review happened," and issuing this approval any
+# earlier would open a merge path around the CodeRabbit gate for the one
+# author who can never be asked to review their own pull request, which is
+# the same hole #114 was about. A contributor or a fork gets no approval
+# from either job and still needs a genuine human review before anything
+# merges; nothing in this file changes for them.
 #
 # pull_request_target, not pull_request, and the difference is the whole
 # defense. Under `pull_request` this file would be read from the pull request's
@@ -29,8 +54,8 @@ name: Bot Auto Merge
 # wait for `Pin Only` below and approve itself, and Renovate does maintain pins
 # in .github/workflows/. pull_request_target runs the default branch's copy
 # instead. It is normally the more dangerous of the two because it hands a write
-# token to a workflow a fork can trigger, which does not apply here: this job
-# never checks out the pull request, and the author condition it is gated on
+# token to a workflow a fork can trigger, which does not apply here: neither
+# job checks out the pull request, and the author condition each is gated on
 # comes from the immutable copy.
 on:
   # zizmor: ignore[dangerous-triggers]
@@ -56,8 +81,8 @@ permissions:
   contents: read
 
 jobs:
-  approve:
-    name: Approve and enable auto-merge
+  approve-bot:
+    name: Approve and enable auto-merge for a dependency bot
     # user.login is set by GitHub from the authenticated author, so a pull
     # request cannot claim to be a bot. Exact equality, not startsWith or
     # contains: `renovate[bot]-x` is a login somebody may register, and the
@@ -256,3 +281,159 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
+
+  approve-owner:
+    name: Approve the owner's own pull request
+    # Exact login match against the immutable pull_request_target payload,
+    # the same fence the bot job above relies on: this is the one account
+    # with write access to this repository, confirmed against the API rather
+    # than assumed, and the non-fork condition is repeated here for the same
+    # reason it is repeated on the bot job, since an owner authored pull
+    # request is never a fork's but trusting that without checking is how
+    # #114 happened. `labeled` and `automerge` are irrelevant here: the
+    # owner's approval does not depend on either.
+    if: >-
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.user.login == 'ivan-pinatti'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # A distinct group from the bot job's, even though the two `if`
+    # conditions above can never both be true for the same pull request: an
+    # owner authored pull request can never also be renovate[bot]'s or
+    # dependabot[bot]'s. Queued rather than cancelled, for the same reason as
+    # the bot job: a superseded run has nothing to redo, but a cancelled one
+    # might have been the only run that would have approved.
+    concurrency:
+      group: bot-auto-merge-owner-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
+
+      - name: Wait for every required context to be green
+        # Every required context, not just `Pin Only` the way the bot job
+        # waits: `Pre-commit`, `Tests`, `Pin Only` and `Review Verified` all
+        # have to read green before this job approves anything, because an
+        # approval issued before `Review Verified` settles would hand the
+        # owner a merge path around the CodeRabbit gate, which is the exact
+        # hole #114 was about, and the owner is the one author who can never
+        # be asked to supply that review themselves.
+        #
+        # `statusCheckRollup`, not the `/commits/{sha}/status` endpoint the
+        # bot job's wait step reads, because two of the four required
+        # contexts here, `Pre-commit` and `Tests`, are ordinary GitHub Checks
+        # (workflow jobs), not commit statuses, and that endpoint only ever
+        # returns the latter. `statusCheckRollup` is the one place both
+        # shapes show up together, the same reasoning
+        # coderabbit-review-queue.yml already relies on for the same reason.
+        #
+        # `Review Verified` is realistically the slowest of the four, since
+        # it depends on CodeRabbit's own review completing, and this job is
+        # only re-triggered by another `pull_request_target` event (a push,
+        # a reopen, or a label), not by a status update the way
+        # coderabbit-gate.yml's `status` trigger is. A pull request whose
+        # checks finish after this two minute window closes gets approved on
+        # its next `synchronize` rather than this one; that is a wait for a
+        # push, not a deadlock, since nothing here withholds anything
+        # permanently, and it fails this step closed rather than approving
+        # on an incomplete read.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          required='["Pre-commit","Tests","Pin Only","Review Verified"]'
+          for _ in $(seq 1 24); do
+            # $owner, $name and $number below are GraphQL query variables,
+            # not shell expansions; they are meant to stay literal inside
+            # the single-quoted query and are bound by the -f/-F arguments
+            # that follow it.
+            # shellcheck disable=SC2016
+            contexts=$(gh api graphql -f query='
+              query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup {
+                            contexts(first: 50) {
+                              nodes {
+                                ... on StatusContext { context state }
+                                ... on CheckRun { name conclusion }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$PR_NUMBER" \
+              --jq '.data.repository.pullRequest.commits.nodes[0].commit
+                    .statusCheckRollup.contexts.nodes // []')
+
+            # A CheckRun can pass as `neutral` or `skipped` as well as
+            # `success`; a StatusContext never reports either, so widening
+            # the accepted set costs nothing here and matches what branch
+            # protection itself treats as a passing required check.
+            # shellcheck disable=SC2016
+            all_green=$(printf '%s' "$contexts" | jq --argjson required "$required" '
+              (map({(.context // .name):
+                    ((.state // .conclusion // "pending") | ascii_downcase)})
+                | add // {}) as $states
+              | (["success", "neutral", "skipped"]) as $passing
+              | ($required
+                  | map(select(($states[.] // "absent") as $s
+                      | ($passing | index($s)) | not))
+                  | length) == 0')
+
+            if [ "$all_green" = "true" ]; then
+              echo "All required contexts are green for #$PR_NUMBER."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Not every required context is green for #$PR_NUMBER."
+          exit 1
+
+      - name: Approve
+        # No decide step here, unlike the bot job: reaching this point at all
+        # already means the author is the owner, the pull request is not a
+        # fork's, and every required context is green, which is the entire
+        # decision. Deduplicated against an existing approval the same way
+        # the bot job is, for the same reason: branch protection dismisses
+        # stale reviews on a rebase, so `synchronize` re-runs this job, and
+        # re-approving every time would pile up identical reviews the way
+        # docker-torrent-box-with-vpn's #61 did before that guard existed.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            | jq -s '[.[][] | select(.user.login == "github-actions[bot]"
+                              and .state == "APPROVED")] | length')
+          if [ "$existing" -gt 0 ]; then
+            echo "Already approved and not dismissed. Nothing to do."
+            exit 0
+          fi
+          gh pr review --approve "$PR_URL"
+
+        # No "Enable auto-merge" step here, deliberately: the owner decides
+        # when to enqueue their own pull request. Supplying the approval is
+        # enough to make it queue eligible; arming auto-merge on top of that
+        # would remove the "I will check everything is fine, then merge"
+        # step the owner explicitly wants to keep for their own work, even
+        # though nothing here would stop the owner running `gh pr merge
+        # --auto` by hand if they wanted the same convenience Renovate gets.

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -75,8 +75,19 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
+  # For the owner's own path only, resolved separately below by
+  # `resolve-owner` rather than filtered here the way `pull_request_target`'s
+  # branch and type list is, because a `status` event carries no pull
+  # request context at all to filter on, only a commit SHA. `Review
+  # Verified` is realistically the slowest of the four required contexts,
+  # since it depends on CodeRabbit's own review completing, and
+  # `pull_request_target` alone never fires again once a pull request stops
+  # changing, so without this trigger a pull request whose review finished
+  # after the first poll window closed would need a push it did not
+  # otherwise need, just to get approved.
+  status:
 
-# The floor. The job widens it for itself.
+# The floor. Each job widens it for itself.
 permissions:
   contents: read
 
@@ -282,29 +293,97 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
 
+  resolve-owner:
+    name: Find the owner's pull request to approve
+    # `status` fires on every commit status this repository receives,
+    # including ones with nothing to do with an owner authored pull request
+    # at all, so this is filtered to the one context whose settling is what
+    # this whole second trigger exists for. `pull_request_target` needs no
+    # such filter: its own type list above already scopes it.
+    if: >-
+      github.event_name != 'status' ||
+      github.event.context == 'Review Verified'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: read
+    outputs:
+      # A JSON array of {pr_number}. Deliberately just the number: unlike
+      # coderabbit-gate.yml's resolve job, nothing here is graded against a
+      # merge queue's temporary commit, so there is no separate head/target
+      # SHA to carry, and the approve job re-reads the pull request fresh
+      # from the number anyway.
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - name: Build the list of owner pull requests to check
+        id: build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          STATUS_SHA: ${{ github.event.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request_target)
+              # Read straight off the immutable payload: cheap, and this is
+              # the same trust boundary the bot job's own `if:` already
+              # relies on.
+              if [ "$PR_AUTHOR" = "ivan-pinatti" ] && [ "$IS_FORK" != "true" ]; then
+                matrix=$(jq -nc --arg n "$PR_NUMBER" '[{pr_number: ($n | tonumber)}]')
+              else
+                matrix='[]'
+              fi
+              ;;
+
+            status)
+              # Asked of the API fresh rather than trusted from the payload,
+              # since a `status` event carries only a commit SHA: zero, one,
+              # or in principle more than one open pull request can share a
+              # head SHA, and each is checked against the same author and
+              # fork conditions as the pull_request_target case above.
+              matrix=$(gh api "repos/$REPO/commits/$STATUS_SHA/pulls" \
+                | jq -c '[.[] | select(.state == "open"
+                                  and .user.login == "ivan-pinatti"
+                                  and (.head.repo.fork // false) == false)
+                          | {pr_number: .number}]')
+              ;;
+
+            *)
+              echo "::error::Unhandled event: $EVENT_NAME"
+              exit 1
+              ;;
+          esac
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Checking: $matrix"
+
   approve-owner:
     name: Approve the owner's own pull request
-    # Exact login match against the immutable pull_request_target payload,
-    # the same fence the bot job above relies on: this is the one account
-    # with write access to this repository, confirmed against the API rather
-    # than assumed, and the non-fork condition is repeated here for the same
-    # reason it is repeated on the bot job, since an owner authored pull
-    # request is never a fork's but trusting that without checking is how
-    # #114 happened. `labeled` and `automerge` are irrelevant here: the
-    # owner's approval does not depend on either.
-    if: >-
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.user.login == 'ivan-pinatti'
+    needs: resolve-owner
+    # An empty array is not an error: nothing to check in, and nothing to
+    # approve. `fromJson('[]')` still starts a matrix with zero jobs, which
+    # reports as success on its own with no step of this job ever running.
+    if: needs.resolve-owner.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # A distinct group from the bot job's, even though the two `if`
-    # conditions above can never both be true for the same pull request: an
-    # owner authored pull request can never also be renovate[bot]'s or
-    # dependabot[bot]'s. Queued rather than cancelled, for the same reason as
-    # the bot job: a superseded run has nothing to redo, but a cancelled one
-    # might have been the only run that would have approved.
+    strategy:
+      fail-fast: false
+      matrix:
+        entry: ${{ fromJson(needs.resolve-owner.outputs.matrix) }}
+    # Keyed on the pull request, not the workflow run, for the same reason
+    # coderabbit-gate.yml's grade job is: two triggers racing to approve the
+    # same pull request is exactly what this serializes, and the dedupe
+    # inside the Approve step below is what stops either of them piling up a
+    # second review once the first lands. Queued rather than cancelled: a
+    # superseded run has nothing to redo, but a cancelled one might have
+    # been the only run that would have approved.
     concurrency:
-      group: bot-auto-merge-owner-${{ github.event.pull_request.number }}
+      group: bot-auto-merge-owner-${{ matrix.entry.pr_number }}
       cancel-in-progress: false
     permissions:
       pull-requests: write
@@ -312,8 +391,20 @@ jobs:
       - name: Check out the default branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+
+      - name: Read the pull request's URL
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ matrix.entry.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          url=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.html_url')
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Wait for every required context to be green
         # Every required context, not just `Pin Only` the way the bot job
@@ -332,20 +423,17 @@ jobs:
         # shapes show up together, the same reasoning
         # coderabbit-review-queue.yml already relies on for the same reason.
         #
-        # `Review Verified` is realistically the slowest of the four, since
-        # it depends on CodeRabbit's own review completing, and this job is
-        # only re-triggered by another `pull_request_target` event (a push,
-        # a reopen, or a label), not by a status update the way
-        # coderabbit-gate.yml's `status` trigger is. A pull request whose
-        # checks finish after this two minute window closes gets approved on
-        # its next `synchronize` rather than this one; that is a wait for a
-        # push, not a deadlock, since nothing here withholds anything
-        # permanently, and it fails this step closed rather than approving
-        # on an incomplete read.
+        # A two minute window is still not a guarantee `Review Verified`
+        # settles inside it, since it depends on CodeRabbit's own review
+        # completing. What makes that survivable rather than a dead end is
+        # the `status` trigger above: this job runs again, and re-reads the
+        # rollup fresh, the moment `Review Verified` actually changes,
+        # rather than depending on this one poll window catching it or on
+        # someone pushing a pull request that has nothing left to change.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ matrix.entry.pr_number }}
         shell: bash
         run: |
           set -euo pipefail
@@ -410,13 +498,14 @@ jobs:
         # fork's, and every required context is green, which is the entire
         # decision. Deduplicated against an existing approval the same way
         # the bot job is, for the same reason: branch protection dismisses
-        # stale reviews on a rebase, so `synchronize` re-runs this job, and
-        # re-approving every time would pile up identical reviews the way
-        # docker-torrent-box-with-vpn's #61 did before that guard existed.
+        # stale reviews on a rebase, so a rebase re-runs this job on a fresh
+        # `pull_request_target` event, and re-approving every time would
+        # pile up identical reviews the way docker-torrent-box-with-vpn's
+        # #61 did before that guard existed.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_NUMBER: ${{ matrix.entry.pr_number }}
           REPO: ${{ github.repository }}
         shell: bash
         run: |

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -24,10 +24,13 @@ linters have not finished cleaning up yet.
 what starts CodeRabbit. Address what it raises, pushing fixes as needed; each
 push re-runs both jobs and gets a fresh review.
 
-Once every required check reads green and a maintainer has approved it,
-GitHub adds the pull request to the merge queue on its own (see "The merge
-queue is live" below), and it merges once the queue's own run of the same
-check set passes on the commit the queue actually builds.
+Once every required check reads green and a maintainer has approved it, the
+pull request is eligible for the merge queue, but entering it still needs
+someone to select **Merge when ready** (or enable auto-merge), the same as
+any GitHub pull request with a merge queue in front of it; nothing here
+enqueues it on its own. Once it is enqueued, it merges when the queue's own
+run of the same check set passes on the commit the queue actually builds;
+see "The merge queue is live" below.
 
 ## The repository owner's own pull request
 
@@ -53,6 +56,13 @@ than for `Pin Only` alone. `Review Verified` is what actually carries "a
 review happened," and nothing else in this pipeline does. A contributor or a
 fork gets no approval from this job and still needs a genuine human review,
 same as always.
+
+`Review Verified` is realistically the slowest of the four contexts to
+settle, since it waits on CodeRabbit's own review, which is why this job
+also reacts to a `status` event on that context landing, not only to
+`pull_request_target`: a pull request whose review finishes well after it
+was opened still gets approved without needing a push it otherwise has no
+reason to make.
 
 ## A dependency bot pull request
 

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -59,10 +59,16 @@ same as always.
 
 `Review Verified` is realistically the slowest of the four contexts to
 settle, since it waits on CodeRabbit's own review, which is why this job
-also reacts to a `status` event on that context landing, not only to
-`pull_request_target`: a pull request whose review finishes well after it
-was opened still gets approved without needing a push it otherwise has no
-reason to make.
+also reacts to `coderabbit-gate.yml` finishing a run (a `workflow_run`
+trigger, not `pull_request_target` alone), re-checking every open owner
+authored pull request each time rather than only the one that happened to
+prompt it: a pull request whose review finishes well after it was opened
+still gets approved without needing a push it otherwise has no reason to
+make. It is `workflow_run`, not a `status` trigger on `Review Verified`
+itself, because `coderabbit-gate.yml` publishes that status with
+`secrets.GITHUB_TOKEN`, and GitHub does not start new workflow runs from
+events a `GITHUB_TOKEN` creates; `workflow_run` reacts to the run finishing
+rather than to that publish, so it is not subject to the same restriction.
 
 ## A dependency bot pull request
 

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -6,10 +6,12 @@ What happens between opening a pull request against this repository and it
 landing on `main`. This is a thinner version of the document of the same
 name in `docker-torrent-box-with-vpn`, which this pipeline was ported from
 ahead of a planned migration of that repository to an organization (GitHub
-refuses a merge queue on a personal account). This repository has four
-required contexts, not six, and no integration suite, so the shape here is
-simpler; where the reasoning is identical it is only summarized, not
-restated.
+refuses a merge queue on a personal account). This repository was the
+rehearsal for that migration: it transferred first, proved the queue works
+under an organization, and the fixes found along the way are meant to sweep
+back into the sibling repository afterward. It has four required contexts,
+not six, and no integration suite, so the shape here is simpler; where the
+reasoning is identical it is only summarized, not restated.
 
 ## A human pull request
 
@@ -23,11 +25,34 @@ what starts CodeRabbit. Address what it raises, pushing fixes as needed; each
 push re-runs both jobs and gets a fresh review.
 
 Once every required check reads green and a maintainer has approved it,
-branch protection allows the merge. There is no merge queue on this
-repository (see "Branch protection: what is live and what is not" below), so
-`strict: true` does that job instead: GitHub requires the pull request to be
-up to date with `main` first, which a stale pull request clears by merging
-`main` into it rather than by anything this pipeline runs.
+GitHub adds the pull request to the merge queue on its own (see "The merge
+queue is live" below), and it merges once the queue's own run of the same
+check set passes on the commit the queue actually builds.
+
+## The repository owner's own pull request
+
+The owner is the only account with write access, and GitHub refuses to let
+an account approve its own pull request, which used to mean a genuine
+deadlock once the queue went live: `gh pr merge --admin` skips the queue
+entirely, and arming auto-merge on an unapproved pull request leaves it
+enqueued forever with no `merge_group` run, because `enforce_admins: false`
+exempts the owner from performing a merge without approval, not from the
+approval the queue itself requires to accept the pull request at all. Both
+failure modes were confirmed empirically, not assumed, on real pull requests
+against this repository.
+
+`bot-auto-merge.yml`'s `approve-owner` job is the fix: once `Pre-commit`,
+`Tests`, `Pin Only` and `Review Verified` are all green, it supplies the
+approval that makes the pull request queue eligible. It does not arm
+auto-merge, deliberately: the owner still decides when to enqueue, which is
+the "check everything is fine, then merge" step the rest of this pipeline
+takes away from nobody else. This approval is not evidence a human read the
+diff; it is issued the moment the four contexts settle, with no review of
+their content, which is exactly why it waits for `Review Verified` rather
+than for `Pin Only` alone. `Review Verified` is what actually carries "a
+review happened," and nothing else in this pipeline does. A contributor or a
+fork gets no approval from this job and still needs a genuine human review,
+same as always.
 
 ## A dependency bot pull request
 
@@ -43,9 +68,9 @@ pin only:
    for `Pin Only` to read `success` and then supplies the approving review
    branch protection requires. A diff that is not pin-only gets no approval
    and waits for a person, same as a major bump does.
-3. **GitHub merges it** once every required check, including `Review
-   Verified`, is green, the approval is in place, and the pull request is up
-   to date with `main` (`strict: true`; see below).
+3. **GitHub enqueues and merges it** once every required check, including
+   `Review Verified`, is green and the approval is in place, the same as any
+   other pull request; see "The merge queue is live" below.
 
 ## Every required status context
 
@@ -136,28 +161,28 @@ the hourly schedule as a convenience that clears most missed runs without
 anyone having to notice, and `workflow_dispatch` as what an actual person
 reaches for when it does not.
 
-## Branch protection: what is live and what is not
+## The merge queue is live
 
-Classic branch protection on `main` requires `Pre-commit`, `Tests`,
-`Pin Only` and `Review Verified`, with `strict: true` (a pull request must be
-up to date with `main` before it merges), one approval, dismissal of stale
-reviews, approval of the last push, conversation resolution and a linear
-history. That means `bot-auto-merge.yml`'s approval now does something real:
-without it, a pin-only bot pull request has no approving review and cannot
-merge, which is the gap that workflow existed to close ahead of need.
+This repository transferred from a personal account to the
+`ivan-pinatti-labs` organization specifically so a `merge_queue` ruleset
+rule could exist at all: GitHub refuses that rule under personal ownership
+and accepts it under an organization, free plan included. Ruleset `21672903`
+is `enforcement: active`, with no bypass actor, so `merge_group` triggers on
+`pull-request-validation.yml` and `coderabbit-gate.yml`, both added ahead of
+need while the queue could not exist yet, are live rather than inert: every
+required context runs a second time against the queue's own temporary
+commit before anything actually merges, exactly as `docker-torrent-box-with-vpn`'s
+own queue does.
 
-Not live: a merge queue. This repository is personal-owned, and GitHub
-refuses a `merge_queue` ruleset rule on a personal account, which is the
-entire reason `docker-torrent-box-with-vpn` is transferring to an
-organization in the first place. `strict: true` here is doing the job a
-queue would otherwise do, at the older cost that made the sibling repository
-move away from it: a pull request has to be rebased or merged up to date with
-`main` itself, and one merge can invalidate every other open pull request's
-checks. `merge_group` triggers on `pull-request-validation.yml` and
-`coderabbit-gate.yml` exist anyway, and stay inert, so that enabling a queue
-after a future transfer does not also require writing new workflow code at
-the same time, which is the entire point of rehearsing this pipeline here
-first.
+Branch protection on `main` requires `Pre-commit`, `Tests`, `Pin Only` and
+`Review Verified`, one approval, dismissal of stale reviews, approval of the
+last push, conversation resolution and a linear history. `enforce_admins` is
+`false`, which matters for exactly one account: it lets the owner merge
+without being blocked by rules an admin can bypass, but it does not exempt
+the owner's own pull request from the approval the queue itself requires to
+accept it, which is what made "The repository owner's own pull request"
+above necessary. `allow_auto_merge` is enabled, without which the queue
+cannot accept anything at all.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the deadlock the merge queue created for the owner's own work:
`enforce_admins: false` exempts the owner from being blocked while
*performing* a merge, but not from the approval a pull request needs to be
*eligible* for the queue at all, and GitHub refuses self approval. Confirmed
empirically rather than assumed:

- `gh pr merge --admin` skips the queue entirely (no `merge_group` run at
  all), on PR #34.
- Arming auto-merge on an unapproved owner pull request leaves it enqueued
  forever with no `merge_group` run either, on PR #31.

## What changed

Adds an `approve-owner` job to `bot-auto-merge.yml`:

- Gated on the immutable `pull_request_target` payload's author being the
  repository owner (`ivan-pinatti`, the sole write collaborator, confirmed
  against the API) and the pull request not being from a fork, the same
  fence shape the existing bot job already uses.
- Waits for **all four** required contexts (`Pre-commit`, `Tests`,
  `Pin Only`, `Review Verified`) to be green before approving, reusing
  `coderabbit-review-queue.yml`'s `statusCheckRollup` GraphQL shape, since
  `Pre-commit`/`Tests` are check runs and `Pin Only`/`Review Verified` are
  commit statuses, and the REST endpoint the bot job's own wait step uses
  only returns the latter. Fails closed (no approval) if any context is
  absent or unsettled.
- Does **not** arm auto-merge. The owner decides when to enqueue their own
  work; the approval only makes the pull request eligible.

The header comment says plainly what this approval does and does not mean:
it is issued the moment the four contexts settle, with no review of the
diff's content, which is exactly why it waits for `Review Verified` (the
context that actually carries "a review happened") rather than `Pin Only`
alone. Approving any earlier would open a merge path around the CodeRabbit
gate for the one author who can never review their own pull request, the
same hole #114 was about. Contributors and forks get no approval from
either job and still need a genuine human review.

`docs/MERGE_PIPELINE.md` also catches up on the transfer: the merge queue
section previously said one was not live because the repository was
personal-owned, which stopped being true once the transfer to
`ivan-pinatti-labs` happened, and it did not describe the owner's own path
at all.

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] `Pre-commit`, `Tests`, `Docker Build` pass on this pull request
- [ ] CodeRabbit review addressed
- [ ] End-to-end proof on a follow-up pull request: opened, four contexts
      green, owner approval appears automatically, enqueued, a real
      `merge_group` run executes, merges out of the queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated approval for repository-owner pull requests after all required checks pass.
  * Added handling for reviews that finish after other checks, without requiring a new push.
  * Improved validation of required checks before approval.
  * Preserved duplicate-approval protection and separate dependency-update handling.

* **Documentation**
  * Updated merge pipeline guidance to reflect the live merge queue.
  * Clarified pull-request eligibility and repository-owner approval behavior.
  * Documented dependency-update merge flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->