### PR TITLE
docs: record what the repository transfer silently changed

### DIFF
--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -200,6 +200,34 @@ accept it, which is what made "The repository owner's own pull request"
 above necessary. `allow_auto_merge` is enabled, without which the queue
 cannot accept anything at all.
 
+## What the transfer silently changed
+
+Recorded here because GitHub's transfer documentation states none of it, and
+each item was found by comparing a snapshot taken before the transfer against
+the repository afterwards rather than by being told.
+
+Survived the transfer: branch protection with all four required contexts,
+Actions secrets by name, both open bot pull requests, and Renovate's
+dependency dashboard issue. Dependabot kept working with no action at all,
+since its version updates are driven by `.github/dependabot.yml` and run by
+GitHub natively rather than by an app installation.
+
+Needed doing by hand afterwards:
+
+- **Secret scanning and push protection were silently disabled.** Both were
+  enabled before the transfer and neither survived it. Push protection is
+  what stops a credential reaching a commit in the first place, so this is a
+  real regression and not a cosmetic one.
+- **`allow_auto_merge` was off**, and a merge queue cannot accept anything
+  without it.
+- **CodeRabbit and Renovate needed reinstalling on the organization.** A
+  GitHub App's installation is granted to an account, not carried by a
+  repository, so both stopped seeing this repository until reinstalled.
+
+Not verifiable here, and left open deliberately: repository *variables* and
+environment level secrets. This repository had none of either before the
+transfer, so their survival was never tested and should not be assumed.
+
 ---
 
 See also: [README.md](../README.md), [CLAUDE.md](../CLAUDE.md)

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -202,9 +202,13 @@ cannot accept anything at all.
 
 ## What the transfer silently changed
 
-Recorded here because GitHub's transfer documentation states none of it, and
-each item was found by comparing a snapshot taken before the transfer against
-the repository afterwards rather than by being told.
+Recorded here because GitHub's transfer documentation does not fully describe
+these effects. It does state that secrets remain associated after a transfer,
+which held. It says nothing either way about branch protection, rulesets,
+repository variables, secret scanning, `allow_auto_merge`, or an app
+installation's scope, and every item below was found by comparing a snapshot
+taken before the transfer against the repository afterwards rather than by
+being told.
 
 Survived the transfer: branch protection with all four required contexts,
 Actions secrets by name, both open bot pull requests, and Renovate's


### PR DESCRIPTION
Records the findings from the transfer to `ivan-pinatti-labs`, none of which GitHub's transfer documentation states. Each came from diffing a pre-transfer snapshot against the repository afterwards.

This pull request is also the **end to end proof of the merge queue**, which has never actually run. The path being tested, in order:

1. Opened by the repository owner
2. Four required contexts go green
3. `bot-auto-merge.yml` supplies the owner's approving review automatically, which landed in #35 and is what makes an owner authored pull request eligible for the queue at all
4. Enqueued
5. **A `merge_group` run executes**, re-running every required context against the queue's own temporary commit
6. Merges out of the queue

Step 5 is the one that matters. `docs/MERGE_PIPELINE.md` already claims it happens; until a `merge_group` run id exists, that claim is untested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how repository transfers affect settings and integrations.
  * Documented preserved repository state and post-transfer actions that may require manual remediation.
  * Noted areas where transfer behavior remains unverified, including repository variables, environment secrets, branch protection, rulesets, secret scanning, automatic merges, and app access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->