### PR TITLE
chore: Renovate automerge eligibility and license detection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -95,8 +95,14 @@ max_line_length = unset
 
 # The verbatim Apache License 2.0 text, centred with spaces exactly as
 # published. It is a legal document reproduced as-is, not something to
-# reformat to a house style.
-[LICENSE.md]
+# reformat to a house style. Plain LICENSE, no extension and nothing added
+# above the text: a Markdown heading and two HTML comments used to sit above
+# it for markdownlint's benefit when this was LICENSE.md, and GitHub's own
+# license detector (licensee) matched the text fine either way, confirmed
+# directly against the gem GitHub itself uses on both the old and the new
+# content. The rename removes the wrapper anyway, since nothing should ever
+# need to be said about a legal document's own formatting again.
+[LICENSE]
 indent_style = unset
 indent_size = unset
 trim_trailing_whitespace = false

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,7 +16,14 @@
   dependencyDashboard: true,
 
   timezone: "America/Toronto",
-  schedule: ["before 7am on Monday"],
+
+  // Daily, not weekly. A weekly schedule stacked against minimumReleaseAge's
+  // 7 day window below means a release that misses one week's slot by a day
+  // waits a full extra week for the next one, so the oldest a package could
+  // sit before merging was up to 14 days even though 7 was the intended
+  // floor. Checking daily keeps the schedule's own period short enough that
+  // it can no longer add more than a day on top of that floor.
+  schedule: ["before 7am"],
 
   labels: ["dependencies"],
   commitMessagePrefix: "chore:",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,12 @@
   // Keep PR volume manageable so CI is not overwhelmed.
   prConcurrentLimit: 5,
   prHourlyLimit: 2,
+
+  // The default deny. Overridden per update type by the first packageRules
+  // entry below, which is the only place that grants it: an update type this
+  // config has not thought about, or a datasource added later with no rule of
+  // its own, arrives unlabelled and waits for a person rather than merging on
+  // the strength of a default nobody chose.
   automerge: false,
 
   // Dependabot owns these two ecosystems; disabling them here avoids
@@ -31,6 +37,41 @@
   enabledManagers: ["asdf", "custom.regex"],
 
   packageRules: [
+    // What may merge without anyone looking, and the label that says so.
+    //
+    // First in the list on purpose, the same reason it is first in
+    // docker-torrent-box-with-vpn's copy of this file: later rules win on any
+    // key they share with an earlier one, and the two group rules below set
+    // names and labels, not automerge policy, so neither can accidentally
+    // override this by coming after it.
+    //
+    // The label is the whole point. bot-auto-merge.yml approves a Renovate
+    // pull request only when it carries `automerge`, reading the label
+    // rather than restating which update types are eligible, so the policy
+    // lives here, once, instead of two copies free to drift apart. `Pin
+    // Only` is the actual security gate behind that trust: every changed
+    // line still has to be nothing but a version in a pin position, checked
+    // line by line, before the label alone can do anything.
+    //
+    // patch and minor only, not this repository's whole update-type
+    // vocabulary. Both of Renovate's ecosystems here can offer a major:
+    // `asdf` for github-cli or pre-commit, and the custom regex manager's
+    // `versioning: docker` for ALPINE_VERSION, where "3.24" to "3.25" reads
+    // as minor but "3.x" to "4.x" would read as major. An Alpine major is
+    // exactly the case CLAUDE.md already says needs a person: apk drops and
+    // renames packages across major releases, which is what forced the apk
+    // pins in the Dockerfile to be re-resolved by hand the last time this
+    // repository's base image moved. `digest` and `pin` are not listed
+    // because neither can happen here: `pinDigests` is not enabled, and
+    // scripts/assert-pin-only-diff.py's own version grammar for the
+    // annotated `.env.example` line has no shape for a digest to occupy, so
+    // granting automerge to an update type this repository never produces
+    // would document a policy nothing here could ever exercise.
+    {
+      matchUpdateTypes: ["patch", "minor"],
+      automerge: true,
+      addLabels: ["automerge"],
+    },
     {
       matchManagers: ["asdf"],
       groupName: "asdf tool versions",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,41 @@
   // duplicate pull requests for the same update.
   enabledManagers: ["asdf", "custom.regex"],
 
+  // A cooling window before an update is offered at all, mirroring
+  // docker-torrent-box-with-vpn's reasoning rather than its number chosen for
+  // a much larger fleet of container images: `Pin Only` proves a diff changed
+  // nothing but a version token, and says so in its own docstring, but it
+  // cannot tell a good release from a backdoored one, because a fresh supply
+  // chain attack has no advisory yet for any scanner to match. Age is the
+  // only defence against that, and granting automerge above without it would
+  // have meant merging a release published minutes earlier, unattended, with
+  // no person ever looking, which is the exact window a compromised upstream
+  // release is exploited in.
+  //
+  // Seven days, the same as the sibling repository, not because the number
+  // was copied but because the reasoning behind it is not about fleet size:
+  // most compromised releases are spotted and pulled within hours to days
+  // regardless of how many images or tools a repository tracks, so the
+  // window that makes "we merged it first" into "it was already yanked" is
+  // the same window here as there. This repository's surface is asdf tool
+  // versions (github-cli, pre-commit) and one annotated Docker tag
+  // (ALPINE_VERSION); none of the three carry a materially different risk
+  // profile that would justify a shorter wait.
+  minimumReleaseAge: "7 days",
+
+  // Hold the pull request until the window is satisfied rather than opening
+  // one that is not allowed to merge yet. Without this, `minimumReleaseAge`
+  // still gates the merge, but Renovate opens the pull request immediately
+  // regardless, so it would sit for up to seven days looking blocked for no
+  // visible reason instead of not existing yet.
+  internalChecksFilter: "strict",
+
+  // The exception: a fix for a known vulnerability is not made safer by
+  // aging, and null clears the inherited window for these updates only.
+  vulnerabilityAlerts: {
+    minimumReleaseAge: null,
+  },
+
   packageRules: [
     // What may merge without anyone looking, and the label that says so.
     //

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,3 @@
-# Apache License 2.0
-
-<!-- Everything below is the Apache License 2.0 reproduced verbatim, including
-    its two-spaces-after-list-marker style (MD030) and its centred layout. It
-    is a legal document quoted as published, not prose to restyle. -->
-<!-- markdownlint-disable -->
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -720,9 +720,9 @@ welcome.
 
 ## License
 
-[![license](https://img.shields.io/github/license/ivan-pinatti-labs/rsync-crypt?style=plastic)](https://github.com/ivan-pinatti-labs/rsync-crypt/blob/main/LICENSE.md)
+[![license](https://img.shields.io/github/license/ivan-pinatti-labs/rsync-crypt?style=plastic)](LICENSE)
 
-See [LICENSE.md](LICENSE.md) for full details.
+See [LICENSE](LICENSE) for full details.
 
 > Licensor provides the Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 > CONDITIONS OF ANY KIND, either express or implied, including, without

--- a/llms.txt
+++ b/llms.txt
@@ -40,7 +40,7 @@ a full local copy.
 ## License
 
 Apache License 2.0. Copyright 2024 Ivan Pinatti.
-Free to use, modify, and distribute; see LICENSE.md for full terms.
+Free to use, modify, and distribute; see LICENSE for full terms.
 
 ## Attribution request
 


### PR DESCRIPTION
## Summary

Two unrelated fixes, combined into one pull request since both are small
and touch disjoint files with no conflict risk; happy to split if that
turns out to be the wrong call.

### The Renovate lane is now proven eligible

`.github/renovate.json5` set `automerge: false` globally with no
`packageRules` entry ever granting it, so PR #30 (a `github-cli` bump) sat
with `Pin Only` and `Review Verified` both green and no `automerge` label
for `bot-auto-merge.yml` to key on. Dependabot's path already decides
eligibility by update type in the workflow; Renovate's now decides its own
in this file, unchanged on the workflow side.

Added one `packageRules` entry, first in the list, granting `automerge:
true` and `addLabels: ["automerge"]` for `patch` and `minor` update types
only:

- Not `digest`/`pin`: `pinDigests` is not enabled here, and
  `scripts/assert-pin-only-diff.py`'s version grammar for the annotated
  `.env.example` line has no shape for a digest to occupy, so neither
  update type can actually occur in this repository.
- Not `major`: an Alpine major on `ALPINE_VERSION` needs a person, per
  CLAUDE.md's own record of what the last base image move required from
  the apk pins in the Dockerfile.

**Proof is pending**, not claimed: Renovate has to re-run on its own
schedule before it can apply the label to PR #30. I have not seen it
happen yet.

### GitHub now has a license file it can actually detect

`gh api repos/ivan-pinatti-labs/rsync-crypt --jq .license` reported
`NOASSERTION` despite `LICENSE.md` carrying the full Apache License 2.0
text. Diagnosed against the actual tool rather than guessed at: `licensee`
(the gem behind GitHub's own detection) matched the old `LICENSE.md` at
100% confidence, both as a standalone file and as a full project scan,
which rules out its content, including the markdownlint heading and HTML
comments at the top, as the cause.

Renamed to a plain `LICENSE` anyway: it removes any residual doubt, it is
what GitHub's own documentation recommends verbatim, and the markdownlint
suppression the old wrapper existed for is now moot, since a file with no
extension is not Markdown and `checklist-markdown`'s `types: [markdown]`
selector never reaches it. Updated every reference: the README badge (now
a relative link, which also sidesteps checking a `blob/main` URL for a
file that does not exist on `main` until this merges), `llms.txt`, and
`.editorconfig`. `CITATION.cff` needed no change, since it names the
license by SPDX identifier.

**I could not prove this fixes the live detection before merging**, since
GitHub only recomputes it against `main`. Will verify against the API
after merge and report the result either way.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Diagnosed the license file directly with `licensee` (the tool
      GitHub's detection actually uses), confirmed via a throwaway
      container, not reasoned about
- [ ] `Pre-commit`, `Tests`, `Docker Build` pass on this pull request
- [ ] CodeRabbit review addressed
- [ ] `gh api repos/ivan-pinatti-labs/rsync-crypt --jq .license` reports
      Apache-2.0 after merge
- [ ] Renovate re-runs and applies `automerge` to PR #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated license references and links to point to the plain-text `LICENSE` file.
  - Simplified the license file formatting while preserving its legal text.
  - Clarified repository guidance for license-file formatting.

- **Chores**
  - Renovate now checks for updates daily.
  - Patch and minor updates can be automatically merged after a seven-day release-age window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->