### PR TITLE
fix: bump rsync apk pin from 3.4 to 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update \
         gocryptfs~=${GOCRYPTFS_VERSION} \
         less~=702 \
         openssh~=10.3 \
-        rsync~=3.4 \
+        rsync~=3.5 \
         sshfs~=3.7 \
         vim~=9.2 \
     && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
Alpine 3.24's package index now serves rsync 3.5.0-r0 only. `apk add rsync~=3.4` fails with `unable to select packages: rsync-3.5.0-r0 breaks: world[rsync~3.4]`, breaking Tests and Docker Build on main and every open PR, independent of any code change.

Verified against `alpine:3.24` directly with `apk policy`: every other pinned package (bash, gocryptfs, less, openssh, sshfs, vim) still matches its existing pin, only rsync moved. Built the image locally with the new pin to confirm it resolves and completes.

Unblocks #41, which was failing Tests/Docker Build for this same unrelated reason.