### PR TITLE
chore: give Dependabot a cooling window, and repoint the checklists library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,20 @@ updates:
       day: monday
       time: "06:30"
       timezone: America/Toronto
+    # Seven days, matching Renovate's minimumReleaseAge in renovate.json5.
+    # Both bots carry the same floor deliberately: `Pin Only` proves a diff
+    # changed nothing but a version and says so in its own docstring, but it
+    # cannot tell a good release from a backdoored one, and these two
+    # ecosystems execute arbitrary code (in CI holding a token, and on a
+    # developer's machine) so they are the larger attack surface, not the
+    # smaller. Applies to version updates only, never to Dependabot security
+    # updates, which is the same carve-out as renovate.json5's
+    # vulnerabilityAlerts.minimumReleaseAge: null. Only default-days is set:
+    # the semver-*-days keys are supported on neither github-actions nor
+    # pre-commit, so setting them would do nothing silently. See
+    # ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md, "Cooling windows".
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - github-actions
@@ -30,6 +44,20 @@ updates:
       day: monday
       time: "06:00"
       timezone: America/Toronto
+    # Seven days, matching Renovate's minimumReleaseAge in renovate.json5.
+    # Both bots carry the same floor deliberately: `Pin Only` proves a diff
+    # changed nothing but a version and says so in its own docstring, but it
+    # cannot tell a good release from a backdoored one, and these two
+    # ecosystems execute arbitrary code (in CI holding a token, and on a
+    # developer's machine) so they are the larger attack surface, not the
+    # smaller. Applies to version updates only, never to Dependabot security
+    # updates, which is the same carve-out as renovate.json5's
+    # vulnerabilityAlerts.minimumReleaseAge: null. Only default-days is set:
+    # the semver-*-days keys are supported on neither github-actions nor
+    # pre-commit, so setting them would do nothing silently. See
+    # ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md, "Cooling windows".
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-# Hooks come from ivan-pinatti/pre-commit-checklists. See docs/hook-catalogue.md
+# Hooks come from ivan-pinatti-labs/pre-commit-checklists. See docs/hook-catalogue.md
 # in that repository for what each id runs, and CLAUDE.md here for the two
 # selectors below that deviate from its shipped templates.
 #
@@ -14,8 +14,8 @@
 # author fixes it. See "CI never autofixes" in CLAUDE.md.
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
-  - repo: https://github.com/ivan-pinatti/pre-commit-checklists
-    rev: v2.2.3
+  - repo: https://github.com/ivan-pinatti-labs/pre-commit-checklists
+    rev: v2.2.4
     hooks:
       # Large-file, merge-conflict and line-ending hygiene. No selector needed.
       - id: checklist-basic

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Contributions, bug reports, and feature requests are welcome!
 ### What the hooks need installed
 
 Linting comes from
-[ivan-pinatti/pre-commit-checklists](https://github.com/ivan-pinatti/pre-commit-checklists),
+[ivan-pinatti-labs/pre-commit-checklists](https://github.com/ivan-pinatti-labs/pre-commit-checklists),
 pinned in `.pre-commit-config.yaml`. Running `pre-commit run --all-files`
 locally needs more than the tool itself does:
 

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -119,13 +119,13 @@ merge of something harmful is two things, neither of them a review:
    can tell a good release from a backdoored one," in its own words.
 2. **A cooling window on both bots**, which is the actual defence against a
    release that is well formed and malicious, since a fresh supply chain
-   compromise may have no published advisory yet, and advisory driven
+   compromise may have no published advisory yet, and advisory-driven
    detection cannot flag what has not been reported. Other signals remain:
    a scanner may match on behaviour rather than a known identifier, and a
    person can inspect release metadata or the published artifact. The
    window buys the time in which any of that can happen.
 
-   Renovate's half is live: `.github/renovate.json5` carries a seven day
+   Renovate's half is live: `.github/renovate.json5` carries a seven-day
    `minimumReleaseAge` with `internalChecksFilter: strict`, so a pull
    request does not open looking blocked before its window is satisfied,
    and `vulnerabilityAlerts.minimumReleaseAge: null`, so a known
@@ -135,8 +135,13 @@ merge of something harmful is two things, neither of them a review:
    the larger surface of the two. Renovate here manages asdf tool versions
    and one annotated Docker tag; Dependabot manages GitHub Actions and
    pre-commit hooks, both of which execute arbitrary code, in CI holding a
-   token and on a developer's machine respectively, and both of which merge
-   unattended once `Pin Only` passes. `.github/dependabot.yml` now sets
+   token and on a developer's machine respectively. When such a bump's diff
+   is pin only, it takes the lane described under "A dependency bot pull
+   request" above: `bot-auto-merge.yml` supplies the approval, `Review
+   Verified` resolves without a review, and it merges with no person having
+   looked at it. A diff that is not pin only gets no approval and waits for
+   a human, so it is the pin-only lane specifically that a cooling window
+   has to cover. `.github/dependabot.yml` now sets
    `cooldown.default-days: 7` on both ecosystems to match. Only
    `default-days` is used: GitHub supports the `semver-*-days` keys on
    neither `github-actions` nor `pre-commit`, so setting them would be

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -117,26 +117,39 @@ merge of something harmful is two things, neither of them a review:
    exists from a version that is safe. `alpine:3.24` becoming `alpine:3.25`
    is exactly the change it exists to permit, "and no amount of diff reading
    can tell a good release from a backdoored one," in its own words.
-2. **Renovate's cooling window**, which is the actual defence against a
+2. **A cooling window on both bots**, which is the actual defence against a
    release that is well formed and malicious, since a fresh supply chain
    compromise may have no published advisory yet, and advisory driven
    detection cannot flag what has not been reported. Other signals remain:
    a scanner may match on behaviour rather than a known identifier, and a
    person can inspect release metadata or the published artifact. The
-   window buys the time in which any of that can happen. As of this
-   writing that window is not yet live in
-   this repository's `.github/renovate.json5`; it is proposed, mirroring
-   `docker-torrent-box-with-vpn`'s own seven day `minimumReleaseAge` with
-   `internalChecksFilter: strict` so a pull request does not open looking
-   blocked before its window is satisfied, and with
-   `vulnerabilityAlerts.minimumReleaseAge: null` so a known vulnerability
-   fix is not held back by a wait that does not make it safer. Treat it as
-   pending until it lands, not as a mitigation already in place.
+   window buys the time in which any of that can happen.
 
-Until that window lands, a clean pin only bump from a compromised or
-misconfigured upstream can merge here as fast as any other clean bump,
-because nothing named above is positioned to catch it. That is the actual
-risk this section exists to name, not the CodeRabbit gap by itself.
+   Renovate's half is live: `.github/renovate.json5` carries a seven day
+   `minimumReleaseAge` with `internalChecksFilter: strict`, so a pull
+   request does not open looking blocked before its window is satisfied,
+   and `vulnerabilityAlerts.minimumReleaseAge: null`, so a known
+   vulnerability fix is not held back by a wait that does not make it safer.
+
+   Dependabot's half was missing entirely until this change, and it covered
+   the larger surface of the two. Renovate here manages asdf tool versions
+   and one annotated Docker tag; Dependabot manages GitHub Actions and
+   pre-commit hooks, both of which execute arbitrary code, in CI holding a
+   token and on a developer's machine respectively, and both of which merge
+   unattended once `Pin Only` passes. `.github/dependabot.yml` now sets
+   `cooldown.default-days: 7` on both ecosystems to match. Only
+   `default-days` is used: GitHub supports the `semver-*-days` keys on
+   neither `github-actions` nor `pre-commit`, so setting them would be
+   configuration that silently does nothing. `cooldown` applies to version
+   updates and never to Dependabot security updates, which is the same
+   carve-out Renovate gets from `vulnerabilityAlerts` above.
+
+The organization-wide statement of this policy, and the reasoning for the
+schedules it interacts with, lives in `ivan-pinatti-labs/.github`'s
+`docs/BOT_SCHEDULE.md` under "Cooling windows". It is recorded there rather
+than only here because every repository in the organization shares it, and
+because the Renovate half of it had already been re-derived incorrectly more
+than once from a repository's config comment alone.
 
 ## Every required status context
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -90,7 +90,7 @@ still open upstream and one already landed.
   on this repo's YAML go away. They are warnings only, since the upstream
   yamllint hook does not pass `--strict`.
 - `.markdown-link-check.json` support landed in `v2.2.1`
-  ([#12 there](https://github.com/ivan-pinatti/pre-commit-checklists/pull/12)),
+  ([#12 there](https://github.com/ivan-pinatti-labs/pre-commit-checklists/pull/12)),
   before this repo's current `v2.2.2` pin, so it already applies. No change
   was needed here: the stars badge was repointed at the repository rather
   than ignored, so this repo needs no ignore file at all.
@@ -432,7 +432,7 @@ five commits on a branch have been reviewed.
 **Why it matters:** the pause is silent. The CodeRabbit check still reports
 green, so a pull request looks reviewed when nothing has read its current
 head. Observed directly on
-[pre-commit-checklists#12](https://github.com/ivan-pinatti/pre-commit-checklists/pull/12),
+[pre-commit-checklists#12](https://github.com/ivan-pinatti-labs/pre-commit-checklists/pull/12),
 a branch with seven commits: reviews stopped after the fifth, and twelve
 hours passed with no review of the head and no indication anything was
 waiting. Recovery needs a manual `@coderabbitai review`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -91,7 +91,7 @@ still open upstream and one already landed.
   yamllint hook does not pass `--strict`.
 - `.markdown-link-check.json` support landed in `v2.2.1`
   ([#12 there](https://github.com/ivan-pinatti-labs/pre-commit-checklists/pull/12)),
-  before this repo's current `v2.2.2` pin, so it already applies. No change
+  before this repo's current `v2.2.4` pin, so it already applies. No change
   was needed here: the stars badge was repointed at the repository rather
   than ignored, so this repo needs no ignore file at all.
 


### PR DESCRIPTION
Two dependency bot changes. Held as a draft while the second half waits on an upstream merge; see "Still to come" at the bottom.

## Dependabot cooling window

Renovate has carried `minimumReleaseAge: "7 days"` for a while, but that only covers the asdf tool surface and the annotated `.env.example` pin. Dependabot had no cooling window at all, in this repository or anywhere else in the organization.

That left the larger of the two surfaces uncovered. Renovate here manages tool versions and one Docker tag; Dependabot manages GitHub Actions and pre-commit hooks, and both of those execute arbitrary code, in CI holding a token and on a developer's machine respectively. Both also merge unattended once `Pin Only` passes, and `scripts/assert-pin-only-diff.py` is explicit in its own docstring that it can tell a structural change from a version change but cannot tell a good release from a backdoored one. Age was the only defence available, and Dependabot had none of it.

`cooldown: { default-days: 7 }` now sits on both ecosystems, matching Renovate's seven days.

`default-days` is the only key used. GitHub supports `semver-major-days`, `semver-minor-days` and `semver-patch-days` on an ecosystem list that includes neither `github-actions` nor `pre-commit`, so setting them here would be configuration that silently does nothing. `cooldown` also applies to version updates only and never to Dependabot security updates, which is the same carve-out Renovate gets from `vulnerabilityAlerts.minimumReleaseAge: null`.

## Documentation drift

`docs/MERGE_PIPELINE.md` still described the Renovate window as "not yet live ... it is proposed" and told the reader to "treat it as pending until it lands", long after it had landed. Anyone reading that section to understand the repository's supply chain posture was being told the opposite of the truth. That passage now describes both halves accurately and points at the organization-wide policy in `ivan-pinatti-labs/.github`'s `docs/BOT_SCHEDULE.md`.

## Still to come on this branch

The `.pre-commit-config.yaml` `repo:` URL still points at `github.com/ivan-pinatti/pre-commit-checklists`, which now redirects. Repointing it to the organization, with a fresh `rev` pin, needs `ivan-pinatti-labs/pre-commit-checklists` to land its own migration first so there is a stable tag to pin to. That commit lands on this branch before it is marked ready, deliberately kept in one pull request rather than two so it costs a single CodeRabbit review slot instead of two. The organization's OSS review quota is shared and is currently the binding constraint on this migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a seven-day cooldown for automated GitHub Actions and pre-commit dependency updates.
  * Updated pre-commit checklist references and advanced the pinned version.

* **Documentation**
  * Corrected repository links and updated the documented checklist version.
  * Documented the seven-day review window for automated updates, including security-update exceptions and pin-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->