### PR TITLE
chore: bump pre-commit-checklists pin to v2.2.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/ivan-pinatti-labs/pre-commit-checklists
-    rev: v2.2.4
+    rev: v2.2.5
     hooks:
       # Large-file, merge-conflict and line-ending hygiene. No selector needed.
       - id: checklist-basic


### PR DESCRIPTION
Bumps the `pre-commit-checklists` pin from v2.2.4 to v2.2.5.

v2.2.5 fixes the branch-name regex in `scripts/check-branch-name.sh` so it accepts a Dependabot branch name where a hook-repo URL gets encoded as `https-/` (see that release's notes, closing ivan-pinatti-labs/github-template#11). Patch-only change in this range; both selectors here already match the library's current templates (per CLAUDE.md, "Selectors match the library's templates"), so no other changes are needed.

`pre-commit run --all-files` passes clean on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code quality checks to the latest pinned checklist revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->