### PR TITLE
chore: run Dependabot daily, standardize the badge row, grade grouped bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,24 @@ version: 2
 # Dependabot handles GitHub Actions and pre-commit hooks.
 # Renovate handles .tool-versions and the version pins in .env.example,
 # see renovate.json5.
+#
+# Both bots run daily. Note that Dependabot's "daily" means weekdays only.
+# This was Monday until 2026-09-02, one weekday out of a per-repository table
+# in ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md, which kept two
+# repositories' bots from opening pull requests in the same hour and queueing
+# behind each other for CodeRabbit's installation-wide review quota. The
+# premise was wrong: a pin-only Dependabot bump resolves `Review Verified`
+# through the bot lane without CodeRabbit ever being asked, exactly as a
+# Renovate bump does, so the table rationed a quota Dependabot never spent
+# while charging a weekly slot that stacked on the seven day cooldown below
+# and made the real floor 7 to 14 days. See that repository's README.md,
+# "Dependency policy".
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
-      time: "06:30"
+      interval: daily
+      time: "06:00"
       timezone: America/Toronto
     # Seven days, matching Renovate's minimumReleaseAge in renovate.json5.
     # Both bots carry the same floor deliberately: `Pin Only` proves a diff
@@ -22,7 +33,7 @@ updates:
     # vulnerabilityAlerts.minimumReleaseAge: null. Only default-days is set:
     # the semver-*-days keys are supported on neither github-actions nor
     # pre-commit, so setting them would do nothing silently. See
-    # ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md, "Cooling windows".
+    # ivan-pinatti-labs/.github's README.md, "Both bots wait seven days".
     cooldown:
       default-days: 7
     labels:
@@ -40,8 +51,7 @@ updates:
   - package-ecosystem: pre-commit
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Toronto
     # Seven days, matching Renovate's minimumReleaseAge in renovate.json5.
@@ -55,7 +65,7 @@ updates:
     # vulnerabilityAlerts.minimumReleaseAge: null. Only default-days is set:
     # the semver-*-days keys are supported on neither github-actions nor
     # pre-commit, so setting them would do nothing silently. See
-    # ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md, "Cooling windows".
+    # ivan-pinatti-labs/.github's README.md, "Both bots wait seven days".
     cooldown:
       default-days: 7
     labels:

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -273,19 +273,25 @@ jobs:
               # dependency's name or version is ever read as jq syntax.
               #
               # shellcheck disable=SC2016
-              result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r '
-                  def ok: . == "version-update:semver-patch" or . == "version-update:semver-minor";
-                  if (type != "array") or length == 0 then
-                    "false\tno updated-dependencies-json to grade"
-                  else
-                    ([.[].updateType | if . == "" or . == null then "unknown" else . end]) as $types
-                    | if ($types | all(ok)) then
-                        "true\tevery bump is patch or minor (\($types | join(", ")))"
+              result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r -s '
+                  def ok: . == "version-update:semver-patch"
+                    or . == "version-update:semver-minor";
+                  if length != 1 then
+                    "false\texpected exactly one JSON value, got \(length)"
+                  else .[0]
+                    | if (type != "array") or length == 0 then
+                        "false\tno updated-dependencies-json to grade"
                       else
-                        "false\tnot every bump is patch or minor (\($types | join(", ")))"
+                        ([.[].updateType
+                          | if . == "" or . == null then "unknown" else . end]) as $types
+                        | if ($types | all(ok)) then
+                            "true\tevery bump is patch or minor (\($types | join(", ")))"
+                          else
+                            "false\tnot every bump is patch or minor (\($types | join(", ")))"
+                          end
                       end
                   end
-                ' 2>/dev/null || echo "")
+                ' 2>/dev/null) || result=""
               if [ -z "$result" ]; then
                 result="false"$'\t'"updated-dependencies-json was empty or invalid JSON"
               fi

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -225,11 +225,35 @@ jobs:
         # metadata action. All three of its ecosystems are eligible, test
         # requirements included: they only reach the test virtualenv, and the
         # suite is what clears them either way.
+        #
+        # Graded from `updated-dependencies-json` alone, never from the
+        # top-level `update-type` output. update-type is fetch-metadata's own
+        # summary of the *highest* semver level *present* among a group's
+        # entries, not a guarantee that *every* entry is at or below that
+        # level: `maxSemver` builds a set of each entry's updateType and
+        # returns the first of major/minor/patch found in it, blank entries
+        # included in the set but never selected over a real one. A group
+        # pairing one resolved minor bump with one blank, unresolved entry
+        # therefore reports the top-level type as "version-update:semver-minor",
+        # confirmed by running fetch-metadata's own algorithm against that
+        # exact shape, which would have approved the whole group on the
+        # strength of the one entry that happened to resolve. Reading
+        # `updated-dependencies-json` unconditionally instead, and requiring
+        # every single entry in it to be a patch or minor bump, closes that
+        # gap without opening a new one: for a genuine single-dependency
+        # update this is the same check the top-level field would have made,
+        # since its one entry is exactly what `update-type` was built from.
+        #
+        # A grouped update is the normal shape here, not an edge case: this
+        # organization's every repository groups its pre-commit and
+        # github-actions ecosystems with `patterns: ["*"]`, so the grouped
+        # shape is the one Dependabot produces most often. Ported from
+        # docker-torrent-box-with-vpn, where #94 was the live example.
         id: decide
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           HAS_AUTOMERGE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'automerge') }}
-          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
         run: |
           approve=false
           arm=false
@@ -243,16 +267,37 @@ jobs:
               fi
               ;;
             "dependabot[bot]")
-              case "$UPDATE_TYPE" in
-                version-update:semver-patch | version-update:semver-minor)
-                  approve=true
-                  # Dependabot cannot arm auto-merge itself, unlike Renovate.
-                  arm=true
-                  ;;
-                *)
-                  echo "::notice::${UPDATE_TYPE:-unknown}: not patch/minor, waits for review."
-                  ;;
-              esac
+              # Every entry has to be a patch or minor bump on its own, one
+              # dependency or many. Piped in on stdin rather than
+              # interpolated into the jq program text, so nothing about a
+              # dependency's name or version is ever read as jq syntax.
+              #
+              # shellcheck disable=SC2016
+              result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r '
+                  def ok: . == "version-update:semver-patch" or . == "version-update:semver-minor";
+                  if (type != "array") or length == 0 then
+                    "false\tno updated-dependencies-json to grade"
+                  else
+                    ([.[].updateType | if . == "" or . == null then "unknown" else . end]) as $types
+                    | if ($types | all(ok)) then
+                        "true\tevery bump is patch or minor (\($types | join(", ")))"
+                      else
+                        "false\tnot every bump is patch or minor (\($types | join(", ")))"
+                      end
+                  end
+                ' 2>/dev/null || echo "")
+              if [ -z "$result" ]; then
+                result="false"$'\t'"updated-dependencies-json was empty or invalid JSON"
+              fi
+              IFS=$'\t' read -r bump_ok bump_reason <<< "$result"
+              if [ "$bump_ok" = "true" ]; then
+                approve=true
+                # Dependabot cannot arm auto-merge itself, unlike Renovate.
+                arm=true
+                echo "::notice::$bump_reason."
+              else
+                echo "::notice::$bump_reason, so it waits for review."
+              fi
               ;;
           esac
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@
 
 ### Encrypted backup over SSH with Docker, gocryptfs, and rsync
 
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![GitHub issues](https://img.shields.io/github/issues/ivan-pinatti-labs/rsync-crypt)](https://github.com/ivan-pinatti-labs/rsync-crypt/issues)
-[![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti-labs/rsync-crypt)](https://github.com/ivan-pinatti-labs/rsync-crypt)
-[![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti-labs/rsync-crypt)](https://github.com/ivan-pinatti-labs/rsync-crypt/forks)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/ivan-pinatti-labs/rsync-crypt?utm_source=oss&utm_medium=github&utm_campaign=ivan-pinatti-labs%2Frsync-crypt&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+[![License](https://img.shields.io/github/license/ivan-pinatti-labs/rsync-crypt?logo=Github&style=for-the-badge)](LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues-raw/ivan-pinatti-labs/rsync-crypt?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti-labs/rsync-crypt/issues)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/ivan-pinatti?logo=Github&style=for-the-badge)](https://github.com/sponsors/ivan-pinatti)
+[![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti-labs/rsync-crypt?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti-labs/rsync-crypt)
+[![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti-labs/rsync-crypt?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti-labs/rsync-crypt/forks)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/ivan-pinatti-labs/rsync-crypt?utm_source=oss&utm_medium=github&utm_campaign=ivan-pinatti-labs%2Frsync-crypt&labelColor=171717&color=FF570A&label=CodeRabbit+Reviews&style=for-the-badge)](https://coderabbit.ai)
 
 Backup your files encrypted to any SSH-accessible server, without trusting the server with your data. Powered by [gocryptfs](https://github.com/rfjakob/gocryptfs) and [rsync](https://rsync.samba.org/), packaged in a minimal Alpine-based Docker image.
 

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -151,10 +151,12 @@ merge of something harmful is two things, neither of them a review:
 
 The organization-wide statement of this policy, and the reasoning for the
 schedules it interacts with, lives in `ivan-pinatti-labs/.github`'s
-`docs/BOT_SCHEDULE.md` under "Cooling windows". It is recorded there rather
-than only here because every repository in the organization shares it, and
-because the Renovate half of it had already been re-derived incorrectly more
-than once from a repository's config comment alone.
+`README.md` under "Dependency policy". It is recorded there rather than only
+here because every repository in the organization shares it, and because it
+had already been re-derived incorrectly more than once from a repository's
+config comment alone. That included the schedule half: Dependabot was given a
+weekday per repository to protect a CodeRabbit review quota its pin-only bumps
+never consumed, and both bots now run daily.
 
 ## Every required status context
 

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -156,13 +156,13 @@ here because every repository in the organization shares it, and because it
 had already been re-derived incorrectly more than once from a repository's
 config comment alone. That included the schedule half: Dependabot was given a
 weekday per repository to protect a CodeRabbit review quota its pin-only bumps
-never consumed, and neither bot is assigned a weekday any more.
+never consumed, and neither bot is assigned a weekday anymore.
 
 They are not on identical days, though, and the difference belongs to
 Dependabot rather than to anything configured here: `interval: daily` means
 weekdays only, Monday to Friday, while Renovate's `before 7am` is permitted
 every day. A release landing on a Saturday reaches Renovate's surfaces that
-morning and Dependabot's on Monday, well inside the seven day cooling window
+morning and Dependabot's on Monday, well inside the seven-day cooling window
 both sit behind.
 
 ## Every required status context

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -156,7 +156,14 @@ here because every repository in the organization shares it, and because it
 had already been re-derived incorrectly more than once from a repository's
 config comment alone. That included the schedule half: Dependabot was given a
 weekday per repository to protect a CodeRabbit review quota its pin-only bumps
-never consumed, and both bots now run daily.
+never consumed, and neither bot is assigned a weekday any more.
+
+They are not on identical days, though, and the difference belongs to
+Dependabot rather than to anything configured here: `interval: daily` means
+weekdays only, Monday to Friday, while Renovate's `before 7am` is permitted
+every day. A release landing on a Saturday reaches Renovate's surfaces that
+morning and Dependabot's on Monday, well inside the seven day cooling window
+both sit behind.
 
 ## Every required status context
 


### PR DESCRIPTION
Three organization-wide changes, bundled because each needs a pull request and none needs one of its own.

**Dependabot runs daily**, matching Renovate. It was on Monday, one weekday out of the table in `ivan-pinatti-labs/.github`'s `docs/BOT_SCHEDULE.md`, which spread repositories so their CodeRabbit review requests would not queue behind each other. A pin-only bump from either bot resolves `Review Verified` through the bot lane with CodeRabbit never asked, so that table rationed a quota Dependabot never spent, while the weekly slot stacked on the seven day cooldown and made the real floor 7 to 14 days. Dependabot's `daily` means weekdays only.

**Badge row matches the organization**: the large `for-the-badge` style, gaining Sponsors. The license badge becomes the dynamic `github/license` one pointing at `LICENSE` (this repository's actual filename), replacing a hardcoded `License-Apache--2.0-blue.svg` that read nothing and pointed at apache.org.

**Grouped Dependabot bumps are graded per entry**, porting the fix from `docker-torrent-box-with-vpn`: every entry in `updated-dependencies-json` must be patch or minor on its own. The top-level `update-type` it replaces reports the highest level *present* in a group, so a group pairing one resolved minor with one unresolved entry reported "minor" and would have been approved on the strength of the entry that resolved.

References to the deleted `BOT_SCHEDULE.md` are repointed in `dependabot.yml` and `docs/MERGE_PIPELINE.md`. All hooks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Dependency update checks now run daily.
  - Automated dependency merges more reliably identify eligible patch and minor updates; incomplete or invalid metadata remains pending review.

- **Documentation**
  - Updated dependency automation guidance to reflect current schedules and organization-wide policy references.

- **Style**
  - Refreshed README badges with a consistent “for-the-badge” style, GitHub branding, updated license information, and a sponsors badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->