### PR TITLE
feat: automate apk pin re-resolution on Alpine version bumps

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -96,6 +96,7 @@
     "ionide",
     "jsonlz",
     "jspm",
+    "keepends",
     "kubeconfig",
     "kubeconfigs",
     "llms",

--- a/.env.example
+++ b/.env.example
@@ -11,24 +11,39 @@ DOCKER_IMAGE_TAG_VERSION="1.0.0"
 ALPINE_VERSION="3.24"
 
 # gocryptfs release to install inside the Docker image.
-# Deliberately not tracked by Renovate: this is an apk version constraint, not a
-# Docker tag, and the resolved build differs in supported flags. Bump it by hand
-# after checking the Alpine community repo, which an ALPINE_VERSION bump forces:
-# Alpine 3.24 dropped gocryptfs 2.5 entirely, so the `~=` constraint in the
-# Dockerfile fails the build until this is bumped with it.
+# This is an apk version constraint, not a Docker tag, so no Renovate
+# datasource models it (see the customManagers comment in
+# .github/renovate.json5): a version Renovate proposed independently could
+# easily not exist in the Alpine release ALPINE_VERSION pins.
+#
+# Resolved automatically instead, by .github/workflows/resolve-apk-pins.yml,
+# whenever a Renovate ALPINE_VERSION pull request lands: it runs
+# `apk policy gocryptfs` inside the new `alpine:<version>` image and pushes a
+# second commit onto the same pull request if the resolved version differs.
+# The `# apk-pin:` line below is what marks this variable eligible for that:
+# see scripts/assert-pin-only-diff.py's APK_PIN_ANNOTATION. It is a marker
+# distinct from `# renovate:` on purpose, so Renovate's own regex manager
+# never tries to track this line itself against the wrong datasource, which
+# is the exact failure this was kept out of Renovate's hands to avoid.
+# apk-pin: resolved-from=ALPINE_VERSION
 GOCRYPTFS_VERSION="2.6"
 
-# The packages below are also apk version constraints, not Docker tags, for the
-# same reason GOCRYPTFS_VERSION is manual: the Alpine community/main repos for a
-# given release carry exactly one version of each package, so all of these move
-# in lockstep with ALPINE_VERSION rather than independently. Deliberately not
-# tracked by Renovate; re-resolve every one of them (`apk policy <pkg>` inside
-# the target `alpine:${ALPINE_VERSION}`) whenever ALPINE_VERSION is bumped.
+# The packages below are also apk version constraints, resolved the same
+# automated way and for the same reason as GOCRYPTFS_VERSION above: the
+# Alpine community/main repos for a given release carry exactly one version
+# of each, so all of these move in lockstep with ALPINE_VERSION rather than
+# independently. See GOCRYPTFS_VERSION's comment for how the marker works.
+# apk-pin: resolved-from=ALPINE_VERSION
 BASH_VERSION="5.3"
+# apk-pin: resolved-from=ALPINE_VERSION
 LESS_VERSION="702"
+# apk-pin: resolved-from=ALPINE_VERSION
 OPENSSH_VERSION="10.3"
+# apk-pin: resolved-from=ALPINE_VERSION
 RSYNC_VERSION="3.5"
+# apk-pin: resolved-from=ALPINE_VERSION
 SSHFS_VERSION="3.7"
+# apk-pin: resolved-from=ALPINE_VERSION
 VIM_VERSION="9.2"
 
 #===============================================================

--- a/.github/workflows/resolve-apk-pins.yml
+++ b/.github/workflows/resolve-apk-pins.yml
@@ -1,0 +1,244 @@
+name: Resolve apk Pins
+
+# GOCRYPTFS_VERSION, BASH_VERSION, LESS_VERSION, OPENSSH_VERSION,
+# RSYNC_VERSION, SSHFS_VERSION and VIM_VERSION in .env.example are apk `~=`
+# version constraints, not Docker tags: no Renovate datasource models "the
+# version of this apk package available in Alpine release X", so an
+# independently tracked bump could propose a version that release's repo does
+# not carry and fail the build (see .github/renovate.json5's customManagers
+# comment). They used to be re-resolved by hand, every time ALPINE_VERSION
+# moved, by running `apk policy <pkg>` inside the new `alpine:<version>` and
+# editing .env.example. This workflow is that step, automated: it runs
+# scripts/resolve-apk-pins.py, which does exactly that, against the
+# ALPINE_VERSION a Renovate pull request proposes, and pushes a second commit
+# onto the same pull request if anything resolved differently.
+#
+# Each of the seven variables carries a `# apk-pin: resolved-from=ALPINE_VERSION`
+# comment immediately above it, not `# renovate:`, on purpose: that is what
+# scripts/assert-pin-only-diff.py's Pin Only check reads to decide a bump to
+# one of them is a pin bump and not "a dependency bot reaching outside its
+# lane" (see that script's APK_PIN_ANNOTATION). Renovate's own custom regex
+# manager is anchored to `# renovate:` specifically, so it never matches this
+# marker and never tries to track these seven independently, which is the
+# exact failure they were kept out of Renovate's hands to avoid in the first
+# place.
+#
+# Why a personal access token, not GITHUB_TOKEN, pushes the commit:
+# GitHub does not start new workflow runs from a push authenticated with the
+# default GITHUB_TOKEN, specifically to stop workflows triggering each other
+# in a loop (the same restriction bot-auto-merge.yml's own comments rely on
+# for `workflow_run` over `status`). Pushing with GITHUB_TOKEN would leave the
+# resolver's commit sitting on the pull request with `Tests` never re-run
+# against it, which fails the one requirement this workflow cannot compromise
+# on: "don't build a parallel test path", the real `Tests` job in
+# pull-request-validation.yml has to grade this commit the normal way.
+# APK_PIN_PUSH_TOKEN is a fine-grained personal access token, scoped to
+# Contents: write on this repository only, the same shape as
+# CODERABBIT_NUDGE_TOKEN in coderabbit-review-queue.yml and for the same
+# underlying reason: a push authenticated as an account is what GitHub
+# actually re-triggers workflows from. If that secret is ever missing or
+# revoked, the push step below fails loudly with a 401 or 403; there is no
+# silent fallback to GITHUB_TOKEN, the same posture coderabbit-review-queue.yml
+# takes for its own PAT.
+#
+# The failure mode this is defensively built around: Renovate's default
+# `rebaseWhen` can rebase or recreate its branch on its own (a later daily
+# run, or the base branch advancing), which can drop this workflow's commit
+# the same way any rebase drops a commit not present on the new base. Nothing
+# here can prevent that rebase; what makes it survivable is that dropping the
+# commit does not desynchronize anything silently. A rebase changes the head
+# SHA, which is a `synchronize` event, which re-triggers this workflow, which
+# recomputes from scratch and reads whatever .env.example the rebased branch
+# actually carries. If the rebase dropped the fix, recomputation finds the
+# same mismatch again and pushes the same fix again; if the rebase somehow
+# kept it, recomputation finds every value already resolved and pushes
+# nothing (`scripts/resolve-apk-pins.py` is idempotent by construction: it
+# only ever writes a value that differs from what is already there). Either
+# way the branch converges back to "every apk pin matches the ALPINE_VERSION
+# it carries" without anyone having to notice the rebase happened. The one
+# thing this does not need is a special case for "my own push retriggered
+# me": that push is authenticated with the PAT rather than GITHUB_TOKEN
+# specifically so it does retrigger, and the second run's own recomputation
+# finding nothing to change is what stops that from looping, not a guard
+# against running twice.
+on:
+  # zizmor: ignore[dangerous-triggers]
+  #
+  # Flagged by default, and the reasoning is bot-auto-merge.yml's: the branch
+  # this reacts to is never a fork's (guarded below), so nothing here is
+  # handing a write-scoped token to code an outside contributor controls.
+  # Unlike bot-auto-merge.yml and coderabbit-gate.yml, this workflow does
+  # check out pull request content, deliberately: it has to read the
+  # ALPINE_VERSION the pull request proposes and, if it resolves something
+  # different, commit onto that same branch. What stays off the pull
+  # request's copy is the code that decides what to do with that content: the
+  # scripts run in every step below are read from the base branch's checkout,
+  # a separate step, never from the pull request's own copy of them. See "Fetch
+  # the pull request's .env.example" and "Resolve apk pins" for exactly what
+  # is and is not read from where.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - ".env.example"
+
+# The floor. Nothing here needs contents: write from GITHUB_TOKEN: the commit
+# is pushed with APK_PIN_PUSH_TOKEN instead, see the header above.
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Re-resolve the apk pins for the proposed Alpine version
+    # Exact equality against renovate[bot], the same fence bot-auto-merge.yml
+    # uses for the same reason: user.login is set by GitHub from the
+    # authenticated author and cannot be spoofed by a pull request body, and
+    # the non-fork check is what makes checking out and pushing to this
+    # branch safe at all, since a fork's branch is not one this repository's
+    # credentials should ever be pushed to.
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # One at a time per pull request. Renovate's own rebase and this
+    # workflow's own follow-up push can both produce a `synchronize` in quick
+    # succession; two overlapping runs computing against two different heads
+    # and racing to push would be exactly the pile-up bot-auto-merge.yml's
+    # concurrency groups exist to prevent, for the same reason. Queued rather
+    # than cancelled: a superseded run has nothing worth cancelling towards,
+    # but a cancelled one might have been the run that would have pushed the
+    # correct fix for the head that mattered.
+    concurrency:
+      group: resolve-apk-pins-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the default branch
+        # Explicit, and load-bearing: this is what makes scripts/resolve-apk-pins.py
+        # and scripts/assert-pin-only-diff.py's own APK_PIN_ANNOTATION the
+        # trusted, reviewed copies rather than whatever a compromised or
+        # misconfigured bot might have rewritten them to say on its own
+        # branch. Only .env.example, fetched separately below, is ever read
+        # from the pull request's branch.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Fetch the pull request's branch into its own worktree
+        id: fetch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --depth 1 origin "$HEAD_REF"
+          # A worktree, not a checkout of this same clone: the commit below
+          # has to land on top of the pull request's actual current head, not
+          # on top of the base branch this step's own checkout is sitting on.
+          # Checking FETCH_HEAD out in place here would overwrite that base
+          # branch checkout, including the trusted copies of the scripts the
+          # next step still needs to run from; a worktree keeps the two
+          # entirely separate on disk while sharing the same object store, so
+          # nothing has to be re-fetched or re-cloned to get both at once.
+          git worktree add ../pr-branch FETCH_HEAD
+
+          # Only worth acting on this pull request at all if ALPINE_VERSION
+          # itself actually moved: the paths filter above already narrows
+          # this to a pull request that touched .env.example, but Renovate's
+          # custom regex manager is the only thing that ever edits that file
+          # on Renovate's own branches, and it only ever touches
+          # ALPINE_VERSION, so this is a defensive check against that
+          # assumption changing later rather than a condition expected to
+          # ever actually trip.
+          base_alpine=$(grep -E '^ALPINE_VERSION=' .env.example)
+          head_alpine=$(grep -E '^ALPINE_VERSION=' ../pr-branch/.env.example)
+          if [ "$base_alpine" = "$head_alpine" ]; then
+            echo "::notice::ALPINE_VERSION did not change on this pull request; nothing to resolve."
+            echo "alpine_changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "alpine_changed=true" >> "$GITHUB_OUTPUT"
+
+          # Digits and dots only, matching resolve-apk-pins.py's own
+          # SAFE_ALPINE_VERSION check. Defence in depth: the script already
+          # refuses anything else before it reaches `docker run`, but failing
+          # here, before this value is interpolated into any command at all,
+          # is cheaper than trusting a second layer to catch what the first
+          # one should never have let through.
+          alpine_version=$(printf '%s\n' "$head_alpine" | sed -E 's/^ALPINE_VERSION="([^"]*)"$/\1/')
+          case "$alpine_version" in
+            '' | *[!0-9.]*)
+              echo "::error::ALPINE_VERSION=$alpine_version is not digits and dots only."
+              exit 1
+              ;;
+          esac
+          echo "alpine_version=$alpine_version" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve apk pins
+        id: resolve
+        if: steps.fetch.outputs.alpine_changed == 'true'
+        env:
+          ALPINE_VERSION: ${{ steps.fetch.outputs.alpine_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The script is the trusted copy from the base branch checkout
+          # above; only the --env-file it rewrites, in the worktree, comes
+          # from the pull request's branch.
+          python3 scripts/resolve-apk-pins.py \
+            --alpine-version "$ALPINE_VERSION" \
+            --env-file ../pr-branch/.env.example \
+            | tee resolve-output.txt
+          changed=$(head -1 resolve-output.txt)
+          echo "$changed" >> "$GITHUB_OUTPUT"
+          # The remaining lines are the human-readable change summary, reused
+          # as the commit body below; a blank summary when nothing changed is
+          # fine, since the commit step is skipped in that case anyway.
+          tail -n +2 resolve-output.txt > resolve-summary.txt
+
+      - name: Commit and push if anything resolved differently
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          APK_PIN_PUSH_TOKEN: ${{ secrets.APK_PIN_PUSH_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          ALPINE_VERSION: ${{ steps.fetch.outputs.alpine_version }}
+        working-directory: ../pr-branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$APK_PIN_PUSH_TOKEN" ]; then
+            echo "::error::APK_PIN_PUSH_TOKEN is not set. A fine-grained personal" \
+              "access token with Contents: write on this repository only is" \
+              "required so this push authenticates as something other than" \
+              "GITHUB_TOKEN and actually retriggers the pull request's required" \
+              "checks; see this workflow's header comment."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .env.example
+          # $GITHUB_WORKSPACE, not a relative "../<repo name>": relative to
+          # this worktree that happens to work when the checkout step's
+          # default path matches the repository's own name, but the
+          # environment variable is what actually names it regardless.
+          {
+            echo "chore: resolve apk pins for alpine $ALPINE_VERSION"
+            echo
+            cat "$GITHUB_WORKSPACE/resolve-summary.txt"
+          } > commit-message.txt
+          git commit --file commit-message.txt
+          rm commit-message.txt
+
+          # HEAD here is this worktree's own head: the pull request's actual
+          # current commit, plus the one just made on top of it, which is
+          # exactly what makes this a fast-forward push rather than a rewrite
+          # of history the pull request's other commits are sitting on.
+          git push \
+            "https://x-access-token:${APK_PIN_PUSH_TOKEN}@github.com/${REPO}.git" \
+            "HEAD:refs/heads/${HEAD_REF}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,71 @@ The `-bs` (block size) flag is NOT supported by this build. Do not add it back.
 
 An `ALPINE_VERSION` bump can invalidate this and the `~=` pins in the
 Dockerfile, which is what those pins are for: the build fails loudly instead
-of silently installing a different major version. Re-resolve every pin against
-the new base image before merging such a bump. Alpine 3.24 moved `gocryptfs`
-2.5 to 2.6, `less` 685 to 702, and `openssh` 10.2 to 10.3.
+of silently installing a different major version.
+
+### apk pins re-resolve themselves when ALPINE_VERSION bumps
+
+`GOCRYPTFS_VERSION`, `BASH_VERSION`, `LESS_VERSION`, `OPENSSH_VERSION`,
+`RSYNC_VERSION`, `SSHFS_VERSION` and `VIM_VERSION` in `.env.example` are apk
+`~=` version constraints, not Docker tags, so no Renovate datasource can
+track them: an independently proposed bump could easily name a version the
+pinned Alpine release's repo does not carry and fail the build. This used to
+mean re-resolving all seven by hand (`apk policy <pkg>` inside the new
+`alpine:${ALPINE_VERSION}`) every time a Renovate `ALPINE_VERSION` pull
+request landed, which is how the 2.5 to 2.6, 685 to 702 and 10.2 to 10.3
+moves above were originally found.
+
+That step is automated now, by `.github/workflows/resolve-apk-pins.yml` and
+`scripts/resolve-apk-pins.py`. When a `renovate[bot]` pull request changes
+`ALPINE_VERSION`, the workflow runs `apk update && apk policy <pkg>` inside
+the proposed `alpine:<version>` for all seven packages and, if anything
+resolves to a different value, pushes a second commit onto the same pull
+request with the update. Each of the seven carries a
+`# apk-pin: resolved-from=ALPINE_VERSION` comment directly above it, a
+marker distinct from Renovate's own `# renovate:` on purpose: it is what
+`scripts/assert-pin-only-diff.py`'s `Pin Only` check reads to accept a bump
+to one of these seven as a pin bump rather than refusing the pull request for
+"a dependency bot reaching outside its lane" (see `APK_PIN_ANNOTATION` in
+that script). It is deliberately not `# renovate:` with a different
+datasource attached: that shape is exactly what Renovate's own regex manager
+matches, which would put these seven right back under Renovate's independent
+tracking, the failure mode they are excluded from Renovate to avoid in the
+first place.
+
+The commit is pushed with a personal access token (`APK_PIN_PUSH_TOKEN`
+secret, fine-grained, `Contents: write` on this repository only), not
+`GITHUB_TOKEN`, the same reasoning as `CODERABBIT_NUDGE_TOKEN` in
+`coderabbit-review-queue.yml`: GitHub does not start new workflow runs from a
+push authenticated with the default `GITHUB_TOKEN`, specifically to prevent
+workflows retriggering each other in a loop, and this repository needs the
+opposite here. The whole point of pushing this commit is that
+`pull-request-validation.yml`'s real `Tests` job (`make build` plus the
+backup/restore roundtrip) grades it the normal way, and a `GITHUB_TOKEN`
+push would leave that job never re-run against it.
+
+Safe to re-run, including when Renovate's own `rebaseWhen` rebases or
+recreates its branch later and drops this workflow's commit the way any
+rebase drops a commit absent from the new base: the rebase changes the head
+SHA, which is a `synchronize` event, which re-triggers this workflow, which
+recomputes from scratch against whatever `.env.example` the rebased branch
+actually carries. `scripts/resolve-apk-pins.py` only ever writes a value
+that differs from what is already there, so a rebase that dropped the fix
+gets it re-applied and a rebase that happened to keep it produces no commit
+at all. Nothing has to detect that a rebase happened; recomputing and
+comparing is what makes it not matter.
+
+`bot-auto-merge.yml` needed no change for this: `Pin Only` grades the pull
+request's cumulative diff (`gh pr diff`), not any one commit, so a second,
+workflow-authored commit on top of Renovate's own is graded the same as if
+it had all been one commit, and the approval job re-triggers correctly on
+the resolver's own `synchronize` event the same way it already does on any
+other push to the pull request.
+
+Only these seven packages resolve automatically. A package newly added to
+the Dockerfile's `apk add` line still needs a person to decide its variable
+name, add it to `.env.example` with the `# apk-pin:` marker, and add it to
+`scripts/resolve-apk-pins.py`'s `PACKAGE_TO_VAR` before this mechanism picks
+it up.
 
 ### rsync exit codes 23 and 24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,24 @@ comments say so.
 - No `ci:` block in `.pre-commit-config.yaml`. That block configures
   pre-commit.ci, whose `autofix_prs` is the only mechanism that would push.
   The app is not installed here (verified against the repo's check runs).
-- No auto-commit or auto-push step in any workflow. Checkouts keep
-  `persist-credentials: false`; jobs hold `contents: read`.
+- No auto-commit or auto-push step in any workflow that grades a pull
+  request's content. Checkouts keep `persist-credentials: false`; jobs hold
+  `contents: read`.
 - A fixable finding fails the PR. The author fixes it locally and pushes.
+
+The one deliberate exception is `.github/workflows/resolve-apk-pins.yml`
+(see "apk pins re-resolve themselves when ALPINE_VERSION bumps" above), and
+it is not really an exception to this policy so much as a different kind of
+automation the policy was never about. `pre-commit` never fixes and pushes
+*findings* from linting the content someone wrote; that stays true and
+unchanged. `resolve-apk-pins.yml` looks up an external fact (what apk version
+a given Alpine release actually carries) that no author, human or bot, can
+know without querying it, and records the answer, the same category of
+automation Renovate and Dependabot already perform on this repository's
+behalf, just for the one datasource neither of them can model. Its checkout
+keeps `persist-credentials: false` too; the push instead uses
+`APK_PIN_PUSH_TOKEN`, a separate, narrowly-scoped credential, deliberately
+not `GITHUB_TOKEN`, for the reasons in that section above.
 
 ### Branch, PR, gates, then merge
 

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -43,10 +43,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # `.pre-commit-config.yaml` (hook `rev:` pins), see .github/dependabot.yml.
 # Renovate manages `.tool-versions` (the asdf manager) and, inside
 # `.env.example`, only the lines its custom regex manager is anchored to (see
-# below and .github/renovate.json5). Neither bot touches `tests/requirements.txt`:
-# dependabot.yml enables only the github-actions and pre-commit ecosystems, so
-# a pip pin bump is not a real bot-authored shape here and is deliberately
-# left off this list.
+# below and .github/renovate.json5). `.env.example` also carries a handful of
+# apk `~=` pins that neither bot manages: .github/workflows/resolve-apk-pins.yml
+# bumps those instead, on the lines its own `# apk-pin:` marker is anchored to
+# (see below), and this script grades that automated commit the same way it
+# grades a bot's. Neither bot touches `tests/requirements.txt`: dependabot.yml
+# enables only the github-actions and pre-commit ecosystems, so a pip pin bump
+# is not a real bot-authored shape here and is deliberately left off this list.
 ALLOWED_PATHS = (
     ".env.example",
     ".pre-commit-config.yaml",
@@ -97,14 +100,26 @@ FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
 # The exact shape .github/renovate.json5's custom regex manager is anchored
 # to: a `# renovate: datasource=... depName=...` comment immediately above the
-# `VAR="value"` line it annotates. Read live off this checkout's own
-# `.env.example` (the base branch's copy, since the workflow that runs this
-# script checks that out rather than the pull request's) so the allowed
-# variable set can never drift from what Renovate is actually configured to
-# manage, and so a bot's pull request cannot smuggle in its own annotation
-# comment to widen what it is allowed to touch: the set is fixed by main's
-# copy of the file, not by the diff being graded.
-ANNOTATION = re.compile(r"^#\s*renovate:")
+# `VAR="value"` line it annotates.
+RENOVATE_ANNOTATION = re.compile(r"^#\s*renovate:")
+
+# The second, distinct marker: a variable resolved automatically by
+# .github/workflows/resolve-apk-pins.yml rather than by Renovate. These are
+# apk `~=` version constraints (GOCRYPTFS_VERSION, BASH_VERSION,
+# LESS_VERSION, OPENSSH_VERSION, RSYNC_VERSION, SSHFS_VERSION,
+# VIM_VERSION), not Docker tags, so no Renovate datasource can track them
+# independently; see the customManagers comment in .github/renovate.json5.
+# Deliberately not `# renovate:` with a different datasource tacked on: that
+# shape is exactly what Renovate's own regex would match, which would put
+# these variables right back under Renovate's independent tracking, the
+# failure mode they are excluded from Renovate to avoid in the first place.
+# `resolved-from=ALPINE_VERSION` is fixed text, not a placeholder: every one
+# of these seven variables is resolved from ALPINE_VERSION today, and a
+# marker naming a different source variable would not match this pattern,
+# so widening it to a genuinely different upstream later is a deliberate,
+# reviewed change to this script rather than a silent grant.
+APK_PIN_ANNOTATION = re.compile(r"^#\s*apk-pin:\s*resolved-from=ALPINE_VERSION\s*$")
+
 ENV_VAR_LINE = re.compile(r"^(?P<name>[A-Z0-9_]+)=")
 # The full quoted value has to be a real release on its own, anchored end to
 # end, not merely contain one: substituting on a partial match would let
@@ -114,8 +129,19 @@ ENV_VAR_LINE = re.compile(r"^(?P<name>[A-Z0-9_]+)=")
 ENV_VALUE = re.compile(r'="(?P<value>[^"]*)"')
 
 
-def annotated_env_vars(path: Path = REPO_ROOT / ".env.example") -> frozenset[str]:
-    """Return the variable names Renovate's custom regex manager may bump."""
+def _env_vars_annotated_by(
+    annotation: re.Pattern[str], path: Path = REPO_ROOT / ".env.example"
+) -> frozenset[str]:
+    """Return the variable names immediately preceded by `annotation`.
+
+    Read live off this checkout's own `.env.example` (the base branch's
+    copy, since the workflow that runs this script checks that out rather
+    than the pull request's) so the allowed variable set can never drift
+    from what the annotation's owner is actually configured to manage, and
+    so a bot's pull request cannot smuggle in its own annotation comment to
+    widen what it is allowed to touch: the set is fixed by main's copy of
+    the file, not by the diff being graded.
+    """
     names = set()
     previous = ""
     try:
@@ -127,13 +153,32 @@ def annotated_env_vars(path: Path = REPO_ROOT / ".env.example") -> frozenset[str
         return frozenset()
     for line in lines:
         var = ENV_VAR_LINE.match(line)
-        if var and ANNOTATION.match(previous):
+        if var and annotation.match(previous):
             names.add(var.group("name"))
         previous = line
     return frozenset(names)
 
 
-ANNOTATED_ENV_VARS = annotated_env_vars()
+def renovate_annotated_env_vars(
+    path: Path = REPO_ROOT / ".env.example",
+) -> frozenset[str]:
+    """Return the variable names Renovate's custom regex manager may bump."""
+    return _env_vars_annotated_by(RENOVATE_ANNOTATION, path)
+
+
+def apk_pin_annotated_env_vars(
+    path: Path = REPO_ROOT / ".env.example",
+) -> frozenset[str]:
+    """Return the variable names resolve-apk-pins.yml may bump."""
+    return _env_vars_annotated_by(APK_PIN_ANNOTATION, path)
+
+
+RENOVATE_ANNOTATED_ENV_VARS = renovate_annotated_env_vars()
+APK_PIN_ANNOTATED_ENV_VARS = apk_pin_annotated_env_vars()
+# The two marker types are semantically distinct (one drives Renovate, the
+# other drives resolve-apk-pins.yml) but grade identically here: either one
+# is enough to let a `VAR="value"` line's value change count as a pin bump.
+PIN_ELIGIBLE_ENV_VARS = RENOVATE_ANNOTATED_ENV_VARS | APK_PIN_ANNOTATED_ENV_VARS
 
 
 def normalize(line: str, path: str = "") -> str:
@@ -142,7 +187,7 @@ def normalize(line: str, path: str = "") -> str:
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", line)
     if path.endswith(".env.example"):
         var = ENV_VAR_LINE.match(line)
-        if var and var.group("name") in ANNOTATED_ENV_VARS:
+        if var and var.group("name") in PIN_ELIGIBLE_ENV_VARS:
             value = ENV_VALUE.search(line)
             if value and re.fullmatch(RELEASE, value.group("value")):
                 return ENV_VALUE.sub('="<version>"', line)

--- a/scripts/resolve-apk-pins.py
+++ b/scripts/resolve-apk-pins.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ivan Pinatti
+"""Re-resolve the apk-constrained version pins in `.env.example`.
+
+`GOCRYPTFS_VERSION`, `BASH_VERSION`, `LESS_VERSION`, `OPENSSH_VERSION`,
+`RSYNC_VERSION`, `SSHFS_VERSION` and `VIM_VERSION` are apk `~=` version
+constraints, not Docker tags: no Renovate datasource models "the version of
+this apk package available in Alpine release X", so these seven are pinned
+by hand against whichever `alpine:${ALPINE_VERSION}` the Dockerfile builds
+from, each carrying a `# apk-pin: resolved-from=ALPINE_VERSION` marker (see
+scripts/assert-pin-only-diff.py) instead of Renovate's own `# renovate:`
+marker.
+
+This script is that hand-resolution, automated. Given an Alpine version, it
+runs `apk update && apk policy <pkg>` inside `alpine:<version>` for each of
+the seven packages, and rewrites `.env.example` in place with whatever it
+finds, at the same precision each variable already uses today (an
+`X.Y.Z-rN` apk version truncated to as many `X.Y...` components as the
+current pin has: `LESS_VERSION="702"` keeps one component, `RSYNC_VERSION`
+keeps two, matching `apk policy`'s own precedence order, which lists the
+version that would actually be installed first).
+
+Used by .github/workflows/resolve-apk-pins.yml, which runs it against the
+`alpine:<version>` a Renovate ALPINE_VERSION pull request proposes and pushes
+a commit if anything changed. Also runnable by hand:
+
+    python3 scripts/resolve-apk-pins.py --alpine-version 3.24
+
+The Docker-shelling half (`resolve_versions`) is kept separate from the pure
+parsing and precision-matching half (`parse_apk_policy`,
+`match_precision`) precisely so the latter can be unit tested with a captured
+`apk policy` transcript and no Docker daemon or network access at all; see
+tests/test_resolve_apk_pins.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = REPO_ROOT / ".env.example"
+
+# apk package name -> the .env.example variable it fills. Alphabetical by
+# package name, which is also the order `apk policy pkg1 pkg2 ...` prints its
+# blocks in, though parse_apk_policy does not depend on that ordering.
+PACKAGE_TO_VAR = {
+    "bash": "BASH_VERSION",
+    "gocryptfs": "GOCRYPTFS_VERSION",
+    "less": "LESS_VERSION",
+    "openssh": "OPENSSH_VERSION",
+    "rsync": "RSYNC_VERSION",
+    "sshfs": "SSHFS_VERSION",
+    "vim": "VIM_VERSION",
+}
+
+# A safe Docker tag: digits and dots only. Alpine release tags never carry
+# anything else (`3.24`, `3.24.1`, `edge`), and `edge` is deliberately not
+# matched here: this script only ever runs against a value Renovate's own
+# `versioning=docker` already validated as a real semver-shaped release, and
+# failing closed on anything unexpected is cheaper than explaining a shell
+# injection into `docker run alpine:<value>` after the fact.
+SAFE_ALPINE_VERSION = re.compile(r"^[0-9]+(\.[0-9]+)*$")
+
+# `apk policy` prints one block per package:
+#   <pkg> policy:
+#     <version>:
+#       <repo url>
+#       ...
+# possibly repeated for older versions still available; the first version
+# line is the one apk would actually install (its own precedence order), so
+# only that line is read per block.
+POLICY_HEADER = re.compile(r"^(?P<pkg>\S+) policy:$")
+POLICY_VERSION = re.compile(r"^  (?P<version>\S+):$")
+
+# The leading numeric-dotted run of an apk version, e.g. "2.6" out of
+# "2.6.1-r5" or "10.3" out of "10.3_p1-r1": apk's own version grammar hangs
+# a `-r<revision>` (package build number) and, on some packages, a
+# `_p<patch>` off the end of the upstream version, and neither belongs in
+# this repository's `~=` pins, which have always named the upstream version
+# only. Stopping at the first character that is not a digit or a dot drops
+# both without having to know each package's own suffix vocabulary.
+VERSION_CORE = re.compile(r"^\d+(?:\.\d+)*")
+
+ENV_VAR_LINE = re.compile(r'^(?P<name>[A-Z0-9_]+)="(?P<value>[^"]*)"$')
+
+
+def parse_apk_policy(output: str) -> dict[str, str]:
+    """Map package name to its first (installable) full apk version."""
+    versions: dict[str, str] = {}
+    pkg = None
+    for line in output.splitlines():
+        header = POLICY_HEADER.match(line)
+        if header:
+            pkg = header.group("pkg")
+            continue
+        if pkg is None or pkg in versions:
+            continue
+        version = POLICY_VERSION.match(line)
+        if version:
+            versions[pkg] = version.group("version")
+    return versions
+
+
+def match_precision(full_version: str, current_pin: str) -> str:
+    """Truncate `full_version` to the component count `current_pin` has.
+
+    `"2.6.1-r5"` matched against a two-component current pin (`"2.6"`)
+    becomes `"2.6"`; `"702-r0"` matched against a one-component pin
+    (`"702"`) stays `"702"`. `apk policy` output that somehow carries fewer
+    components than the current pin (an Alpine release that dropped a
+    version segment) is returned as-is, short rather than padded, so a
+    genuine shape change is visible in the diff instead of being silently
+    stretched to fit.
+    """
+    core = VERSION_CORE.match(full_version)
+    if not core:
+        return full_version
+    components = core.group(0).split(".")
+    want = max(current_pin.count(".") + 1, 1)
+    return ".".join(components[:want])
+
+
+def read_current_pins(env_file: Path) -> dict[str, str]:
+    """Read the seven apk-pinned variables' current values from .env.example."""
+    current: dict[str, str] = {}
+    wanted = set(PACKAGE_TO_VAR.values())
+    for line in env_file.read_text().splitlines():
+        match = ENV_VAR_LINE.match(line)
+        if match and match.group("name") in wanted:
+            current[match.group("name")] = match.group("value")
+    missing = wanted - current.keys()
+    if missing:
+        raise SystemExit(
+            f"{env_file}: missing expected variable(s): {', '.join(sorted(missing))}"
+        )
+    return current
+
+
+def resolve_versions(alpine_version: str) -> dict[str, str]:
+    """Run `apk update && apk policy <pkgs>` inside `alpine:<version>`."""
+    if not SAFE_ALPINE_VERSION.match(alpine_version):
+        raise SystemExit(
+            f"refusing to use {alpine_version!r} as a Docker tag: "
+            "expected digits and dots only"
+        )
+    packages = sorted(PACKAGE_TO_VAR)
+    script = "apk update >&2 && apk policy " + " ".join(packages)
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            f"alpine:{alpine_version}",
+            "sh",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SystemExit(
+            f"apk policy inside alpine:{alpine_version} failed "
+            f"(exit {result.returncode})"
+        )
+    return parse_apk_policy(result.stdout)
+
+
+def apply(env_file: Path, resolved: dict[str, str]) -> list[str]:
+    """Rewrite `env_file` with `resolved` values; return a change summary."""
+    current = read_current_pins(env_file)
+    changes = []
+    new_values: dict[str, str] = {}
+    for pkg, var in sorted(PACKAGE_TO_VAR.items()):
+        full = resolved.get(pkg)
+        if full is None:
+            raise SystemExit(f"apk policy reported nothing for package {pkg!r}")
+        new_value = match_precision(full, current[var])
+        new_values[var] = new_value
+        if new_value != current[var]:
+            changes.append(f"{var}: {current[var]} -> {new_value}")
+
+    if changes:
+        lines = env_file.read_text().splitlines(keepends=True)
+        rewritten = []
+        for line in lines:
+            match = ENV_VAR_LINE.match(line.rstrip("\n"))
+            if match and match.group("name") in new_values:
+                name = match.group("name")
+                newline = "\n" if line.endswith("\n") else ""
+                rewritten.append(f'{name}="{new_values[name]}"{newline}')
+            else:
+                rewritten.append(line)
+        env_file.write_text("".join(rewritten))
+
+    return changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--alpine-version",
+        required=True,
+        help="Alpine release to resolve the apk pins against, e.g. 3.24",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=ENV_FILE,
+        help="Path to .env.example (default: repo root's copy)",
+    )
+    args = parser.parse_args()
+
+    resolved = resolve_versions(args.alpine_version)
+    changes = apply(args.env_file, resolved)
+
+    if changes:
+        print("changed=true")
+        print(f"Resolved apk pins for alpine:{args.alpine_version}:")
+        for change in changes:
+            print(f"  {change}")
+    else:
+        print("changed=false")
+        print(f"apk pins already match alpine:{args.alpine_version}; nothing to do.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -84,12 +84,56 @@ def test_accepts_a_tool_versions_bump():
 
 def test_accepts_the_renovate_annotated_alpine_line():
     # ALPINE_VERSION is the one line in .env.example a renovate: comment
-    # anchors, and it is the only variable this script reads live off
-    # .env.example as eligible for a version bump.
+    # anchors, and it is the only variable Renovate's own manager may bump.
     result = _check(
         _diff(
             ".env.example",
             '-ALPINE_VERSION="3.24"\n+ALPINE_VERSION="3.25"\n',
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_accepts_an_apk_pin_annotated_line():
+    # GOCRYPTFS_VERSION carries the distinct `# apk-pin:` marker
+    # resolve-apk-pins.yml is anchored to, not `# renovate:`; this is the
+    # marker this script's own APK_PIN_ANNOTATION is built to recognize.
+    result = _check(
+        _diff(
+            ".env.example",
+            '-GOCRYPTFS_VERSION="2.6"\n+GOCRYPTFS_VERSION="2.7"\n',
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_accepts_every_apk_pin_annotated_variable_bumped_together():
+    # resolve-apk-pins.yml can touch any subset of the seven in one commit,
+    # not just one at a time.
+    result = _check(
+        _diff(
+            ".env.example",
+            '-BASH_VERSION="5.3"\n+BASH_VERSION="5.4"\n'
+            '-LESS_VERSION="702"\n+LESS_VERSION="703"\n'
+            '-OPENSSH_VERSION="10.3"\n+OPENSSH_VERSION="10.4"\n'
+            '-RSYNC_VERSION="3.5"\n+RSYNC_VERSION="3.6"\n'
+            '-SSHFS_VERSION="3.7"\n+SSHFS_VERSION="3.8"\n'
+            '-VIM_VERSION="9.2"\n+VIM_VERSION="9.3"\n',
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_accepts_alpine_and_apk_pin_bumps_together_in_one_diff():
+    # The real shape resolve-apk-pins.yml produces: its commit lands on top
+    # of Renovate's own ALPINE_VERSION commit, so the pull request's
+    # cumulative diff carries both a renovate: annotated bump and one or
+    # more apk-pin: annotated bumps at once.
+    result = _check(
+        _diff(
+            ".env.example",
+            '-ALPINE_VERSION="3.24"\n+ALPINE_VERSION="3.25"\n'
+            '-GOCRYPTFS_VERSION="2.6"\n+GOCRYPTFS_VERSION="2.7"\n',
         )
     )
     assert result.returncode == 0, result.stdout
@@ -100,23 +144,11 @@ def test_accepts_the_renovate_annotated_alpine_line():
 # ---------------------------------------------------------------------------
 
 
-def test_refuses_gocryptfs_version_despite_looking_like_a_pin():
-    # CLAUDE.md and .env.example's own comment say this one is bumped by
-    # hand: it is an apk version constraint, not a Docker tag, and no
-    # renovate: annotation sits above it. A script that normalized any
-    # `*_VERSION="..."` line would wave this through.
-    result = _check(
-        _diff(
-            ".env.example",
-            '-GOCRYPTFS_VERSION="2.6"\n+GOCRYPTFS_VERSION="2.7"\n',
-        )
-    )
-    assert result.returncode == 1, result.stdout
-
-
 def test_refuses_docker_image_tag_version_despite_looking_like_a_pin():
-    # DOCKER_IMAGE_TAG_VERSION is a local build tag with no upstream to track
-    # and no renovate: annotation above it either.
+    # DOCKER_IMAGE_TAG_VERSION is a local build tag with no upstream to
+    # track, and no annotation of either kind (renovate: or apk-pin:) above
+    # it. A script that normalized any `*_VERSION="..."` line would wave
+    # this through.
     result = _check(
         _diff(
             ".env.example",
@@ -324,11 +356,13 @@ def test_refuses_a_github_action_sha_trading_for_a_floating_tag():
 
 
 def test_refuses_an_unannotated_sibling_bumped_alongside_the_annotated_line():
-    # .env.example carries several other `*_VERSION="..."` lines besides
-    # ALPINE_VERSION (GOCRYPTFS_VERSION, BASH_VERSION, RSYNC_VERSION, and
-    # friends), none of them renovate-annotated. A diff that bumps the real,
-    # annotated ALPINE_VERSION line cleanly must still be refused if it
-    # smuggles a bump to one of those unannotated siblings in alongside it:
+    # .env.example's other `*_VERSION="..."` lines besides ALPINE_VERSION are
+    # all apk-pin: annotated now (GOCRYPTFS_VERSION, BASH_VERSION,
+    # RSYNC_VERSION and friends), so DOCKER_IMAGE_TAG_VERSION is the one
+    # genuinely unannotated version-shaped sibling left: a local build tag
+    # with no annotation of either kind above it. A diff that bumps the
+    # real, annotated ALPINE_VERSION line cleanly must still be refused if
+    # it smuggles a bump to that unannotated sibling in alongside it:
     # per-variable-name gating has to hold even when several version-shaped
     # lines change in the same file at once.
     result = _check(
@@ -336,8 +370,8 @@ def test_refuses_an_unannotated_sibling_bumped_alongside_the_annotated_line():
             ".env.example",
             '-ALPINE_VERSION="3.24"\n'
             '+ALPINE_VERSION="3.25"\n'
-            '-RSYNC_VERSION="3.5"\n'
-            '+RSYNC_VERSION="3.6"\n',
+            '-DOCKER_IMAGE_TAG_VERSION="1.0.0"\n'
+            '+DOCKER_IMAGE_TAG_VERSION="1.0.1"\n',
         )
     )
     assert result.returncode == 1, result.stdout
@@ -351,6 +385,19 @@ def test_refuses_a_non_version_payload_in_an_annotated_env_line():
         _diff(
             ".env.example",
             '-ALPINE_VERSION="3.24"\n+ALPINE_VERSION="$(payload)"\n',
+        )
+    )
+    assert result.returncode == 1, result.stdout
+
+
+def test_refuses_a_non_version_payload_in_an_apk_pin_annotated_env_line():
+    # Same requirement, the other marker: apk-pin: annotation makes
+    # GOCRYPTFS_VERSION eligible for a bump, not eligible for any edit at
+    # all.
+    result = _check(
+        _diff(
+            ".env.example",
+            '-GOCRYPTFS_VERSION="2.6"\n+GOCRYPTFS_VERSION="$(payload)"\n',
         )
     )
     assert result.returncode == 1, result.stdout

--- a/tests/test_resolve_apk_pins.py
+++ b/tests/test_resolve_apk_pins.py
@@ -1,0 +1,249 @@
+"""Tests for scripts/resolve-apk-pins.py.
+
+Exercises only the pure parsing and precision-matching functions
+(`parse_apk_policy`, `match_precision`, `apply`), never `resolve_versions`
+itself, which shells out to Docker: these run anywhere, with no Docker
+daemon and no network, the same way the sibling `assert-pin-only-diff.py`
+tests do.
+
+    pytest -m scripts tests/test_resolve_apk_pins.py
+
+The `apk policy` transcript fixtures below are a real capture, taken by
+running scripts/resolve-apk-pins.py's own docker invocation against
+`alpine:3.24` on 2026-09-03: `apk policy bash gocryptfs less openssh rsync
+sshfs vim`. That is also, not coincidentally, the exact Alpine release and
+package set `.env.example` is pinned to today, which is what lets
+`test_matches_every_current_pin_exactly` assert the resolver reproduces
+every one of the seven live values with no fixture rigged to match.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "resolve-apk-pins.py"
+
+pytestmark = pytest.mark.scripts
+
+
+def _load_module():
+    # The script has a hyphen in its filename, so it cannot be imported as
+    # `resolve_apk_pins` the normal way; loaded explicitly from its path
+    # instead, the same shape a hyphenated script under scripts/ always
+    # needs here.
+    spec = importlib.util.spec_from_file_location("resolve_apk_pins", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+resolve_apk_pins = _load_module()
+
+# A real `apk policy bash gocryptfs less openssh rsync sshfs vim` transcript
+# from inside `alpine:3.24`, captured 2026-09-03. Deliberately not sorted the
+# way PACKAGE_TO_VAR is: apk prints packages in the order they were asked
+# for, and parse_apk_policy must not depend on any particular order.
+ALPINE_3_24_POLICY = """\
+bash policy:
+  5.3.9-r1:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+gocryptfs policy:
+  2.6.1-r5:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/community
+less policy:
+  702-r0:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+openssh policy:
+  10.3_p1-r1:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+rsync policy:
+  3.5.0-r0:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+sshfs policy:
+  3.7.6-r0:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+vim policy:
+  9.2.1014-r0:
+    https://dl-cdn.alpinelinux.org/alpine/v3.24/community
+"""
+
+# The .env.example precision each variable is pinned at today, read straight
+# off the file rather than hardcoded a second time, so this test cannot drift
+# from what is actually committed.
+CURRENT_PINS = resolve_apk_pins.read_current_pins(REPO_ROOT / ".env.example")
+
+
+# ---------------------------------------------------------------------------
+# parse_apk_policy: reading apk's own transcript
+# ---------------------------------------------------------------------------
+
+
+def test_parses_every_package_block():
+    versions = resolve_apk_pins.parse_apk_policy(ALPINE_3_24_POLICY)
+    assert versions == {
+        "bash": "5.3.9-r1",
+        "gocryptfs": "2.6.1-r5",
+        "less": "702-r0",
+        "openssh": "10.3_p1-r1",
+        "rsync": "3.5.0-r0",
+        "sshfs": "3.7.6-r0",
+        "vim": "9.2.1014-r0",
+    }
+
+
+def test_takes_the_first_version_when_several_are_listed():
+    # apk policy lists every available version under a package, most
+    # preferred first; only the first is what would actually be installed.
+    transcript = (
+        "gocryptfs policy:\n"
+        "  2.6.1-r5:\n"
+        "    https://dl-cdn.alpinelinux.org/alpine/v3.24/community\n"
+        "  2.5.0-r0:\n"
+        "    https://dl-cdn.alpinelinux.org/alpine/v3.24/community\n"
+    )
+    assert resolve_apk_pins.parse_apk_policy(transcript) == {"gocryptfs": "2.6.1-r5"}
+
+
+def test_ignores_repository_url_lines():
+    # A repo URL is indented four spaces, not two, and never ends in ":" the
+    # way a version line's own colon-terminated shape does; parse_apk_policy
+    # must not mistake one for a second version.
+    transcript = (
+        "bash policy:\n"
+        "  5.3.9-r1:\n"
+        "    https://dl-cdn.alpinelinux.org/alpine/v3.24/main\n"
+    )
+    assert resolve_apk_pins.parse_apk_policy(transcript) == {"bash": "5.3.9-r1"}
+
+
+# ---------------------------------------------------------------------------
+# match_precision: truncating to the shape .env.example already commits to
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("full_version", "current_pin", "expected"),
+    [
+        ("2.6.1-r5", "2.6", "2.6"),
+        ("702-r0", "702", "702"),
+        ("10.3_p1-r1", "10.3", "10.3"),
+        ("5.3.9-r1", "5.3", "5.3"),
+        ("3.5.0-r0", "3.5", "3.5"),
+        ("3.7.6-r0", "3.7", "3.7"),
+        ("9.2.1014-r0", "9.2", "9.2"),
+    ],
+)
+def test_matches_the_current_pins_precision(full_version, current_pin, expected):
+    assert resolve_apk_pins.match_precision(full_version, current_pin) == expected
+
+
+def test_matches_every_current_pin_exactly():
+    # The point of the whole script: resolving alpine:3.24 today must
+    # reproduce every one of the seven values .env.example already carries,
+    # since that is what alpine:3.24 was verified against by hand before
+    # this script existed (see CLAUDE.md, "Alpine gocryptfs version").
+    versions = resolve_apk_pins.parse_apk_policy(ALPINE_3_24_POLICY)
+    for pkg, var in resolve_apk_pins.PACKAGE_TO_VAR.items():
+        resolved = resolve_apk_pins.match_precision(versions[pkg], CURRENT_PINS[var])
+        assert resolved == CURRENT_PINS[var], f"{var}: expected no change"
+
+
+def test_truncates_a_longer_full_version_to_one_component():
+    assert resolve_apk_pins.match_precision("5.3.9-r1", "702") == "5"
+
+
+def test_a_non_numeric_version_is_returned_unchanged():
+    # apk policy always prints a real version, never a floating word, but a
+    # transcript this script cannot parse as a version must not crash or
+    # silently coerce into something that looks like a bump.
+    assert resolve_apk_pins.match_precision("unknown", "2.6") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# apply: rewriting .env.example, and leaving everything else alone
+# ---------------------------------------------------------------------------
+
+
+def _write_env(tmp_path, overrides):
+    base = {
+        "BASH_VERSION": "5.3",
+        "GOCRYPTFS_VERSION": "2.6",
+        "LESS_VERSION": "702",
+        "OPENSSH_VERSION": "10.3",
+        "RSYNC_VERSION": "3.5",
+        "SSHFS_VERSION": "3.7",
+        "VIM_VERSION": "9.2",
+    }
+    base.update(overrides)
+    path = tmp_path / ".env.example"
+    lines = [
+        'DOCKER_IMAGE_TAG_VERSION="1.0.0"',
+        'ALPINE_VERSION="3.24"',
+        *[f'{name}="{value}"' for name, value in base.items()],
+        "PARANOID_MODE=false",
+        "",
+    ]
+    path.write_text("\n".join(lines))
+    return path
+
+
+def test_apply_reports_no_changes_when_everything_already_matches(tmp_path):
+    path = _write_env(tmp_path, {})
+    before = path.read_text()
+    changes = resolve_apk_pins.apply(
+        path, resolve_apk_pins.parse_apk_policy(ALPINE_3_24_POLICY)
+    )
+    assert changes == []
+    assert path.read_text() == before
+
+
+def test_apply_rewrites_only_the_pins_that_changed(tmp_path):
+    path = _write_env(tmp_path, {"GOCRYPTFS_VERSION": "2.5", "LESS_VERSION": "685"})
+    changes = resolve_apk_pins.apply(
+        path, resolve_apk_pins.parse_apk_policy(ALPINE_3_24_POLICY)
+    )
+    assert sorted(changes) == [
+        "GOCRYPTFS_VERSION: 2.5 -> 2.6",
+        "LESS_VERSION: 685 -> 702",
+    ]
+    rewritten = path.read_text()
+    assert 'GOCRYPTFS_VERSION="2.6"' in rewritten
+    assert 'LESS_VERSION="702"' in rewritten
+    # Untouched lines, including the unrelated ALPINE_VERSION and
+    # DOCKER_IMAGE_TAG_VERSION pins, must survive byte for byte.
+    assert 'ALPINE_VERSION="3.24"' in rewritten
+    assert 'DOCKER_IMAGE_TAG_VERSION="1.0.0"' in rewritten
+    assert "PARANOID_MODE=false" in rewritten
+
+
+def test_apply_raises_if_apk_policy_never_reported_a_package(tmp_path):
+    path = _write_env(tmp_path, {})
+    incomplete = resolve_apk_pins.parse_apk_policy(ALPINE_3_24_POLICY)
+    del incomplete["vim"]
+    with pytest.raises(SystemExit):
+        resolve_apk_pins.apply(path, incomplete)
+
+
+def test_read_current_pins_raises_on_a_missing_variable(tmp_path):
+    path = tmp_path / ".env.example"
+    path.write_text('BASH_VERSION="5.3"\n')
+    with pytest.raises(SystemExit):
+        resolve_apk_pins.read_current_pins(path)
+
+
+# ---------------------------------------------------------------------------
+# resolve_versions: the one function that shells out, guarded before it does
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["3.24; rm -rf /", "$(id)", "3.24 && curl evil", "", "edge", "3.24\ntrap"],
+)
+def test_refuses_an_unsafe_alpine_version_before_touching_docker(value):
+    with pytest.raises(SystemExit):
+        resolve_apk_pins.resolve_versions(value)


### PR DESCRIPTION
## Summary

GOCRYPTFS_VERSION, BASH_VERSION, LESS_VERSION, OPENSSH_VERSION, RSYNC_VERSION,
SSHFS_VERSION and VIM_VERSION are apk `~=` version constraints, not Docker
tags, so no Renovate datasource can track them: an independently proposed
bump could easily name a version the pinned Alpine release's repo does not
carry and fail the build. Until now these seven had to be re-resolved by hand
(`apk policy <pkg>` inside the new `alpine:${ALPINE_VERSION}`) every time a
Renovate `ALPINE_VERSION` pull request landed.

This automates that step:

- **`.github/workflows/resolve-apk-pins.yml`** (new): triggers when a
  `renovate[bot]` pull request changes `ALPINE_VERSION` in `.env.example`.
  Runs `scripts/resolve-apk-pins.py` against the proposed `alpine:<version>`
  and, if anything resolves differently, pushes a second commit onto the same
  pull request.
- **`scripts/resolve-apk-pins.py`** (new): runs `apk update && apk policy
  <pkg>` inside `alpine:<version>` for all seven packages, and truncates each
  resolved version to the precision `.env.example` already commits to (e.g.
  `10.3_p1-r1` -> `10.3`, `702-r0` -> `702`).
- **`.env.example`**: each of the seven variables now carries a
  `# apk-pin: resolved-from=ALPINE_VERSION` comment directly above it, a
  marker distinct from Renovate's own `# renovate:` on purpose, so Renovate's
  regex manager never tracks these seven independently (the exact failure
  they were excluded from Renovate to avoid in the first place).
- **`scripts/assert-pin-only-diff.py`**: recognizes either marker
  (`# renovate:` or `# apk-pin:`) as making a `.env.example` variable
  pin-bumpable, so the `Pin Only` check still accepts the combined diff a
  Renovate bump plus this workflow's follow-up commit produces.
- **`CLAUDE.md`**: replaces the stale "bump these seven by hand" gotcha with
  the new mechanism, including the marker syntax and the rebase-safety
  reasoning.

## Why a personal access token pushes the commit

`GITHUB_TOKEN` pushes do not retrigger new workflow runs (to prevent
recursive triggering), which would leave `pull-request-validation.yml`'s real
`Tests` job (`make build` + backup/restore roundtrip) never re-run against
this commit. `APK_PIN_PUSH_TOKEN` (fine-grained PAT, `Contents: write` on
this repo only) is the same shape as `CODERABBIT_NUDGE_TOKEN` in
`coderabbit-review-queue.yml`, for the same underlying reason.

**This secret needs to be added to the repository before this workflow can
push anything.** Until then, the workflow will trigger, resolve the pins
correctly, and fail loudly with a clear error at the push step rather than
merging anything unresolved.

## Rebase safety

Renovate's `rebaseWhen` can rebase or recreate its branch later and drop this
workflow's commit, the way any rebase drops a commit absent from the new
base. That is not specially guarded against; it does not need to be. A rebase
changes the head SHA, which is a `synchronize` event, which re-triggers this
workflow, which recomputes from scratch. `resolve-apk-pins.py` only ever
writes a value that differs from what is already there, so a rebase that
dropped the fix gets it re-applied, and a rebase that happened to keep it
produces no commit at all (checked with a local test:
`test_apply_reports_no_changes_when_everything_already_matches`).

## `bot-auto-merge.yml`

No change needed, verified rather than assumed: `Pin Only` grades the pull
request's cumulative diff (`gh pr diff`), not any single commit, so a second,
workflow-authored commit on top of Renovate's own is graded identically to if
it had all been one commit. The approval job already re-triggers correctly on
any `synchronize` event, including this workflow's own push.

## Test plan

- [x] `pre-commit run --all-files` (clean)
- [x] `pytest tests --verbose` (146 passed, full suite including `make build`
      and the backup/restore roundtrip against a real container)
- [x] `scripts/resolve-apk-pins.py` run locally against real `alpine:3.24`
      via Docker: reproduces every one of the seven current pins exactly (no
      fixture rigged to match; see `test_matches_every_current_pin_exactly`)
- [x] `scripts/assert-pin-only-diff.py` manually checked against a combined
      `ALPINE_VERSION` + apk-pin diff (accepts) and a diff smuggling a
      non-pin change alongside a real bump (refuses)
- [ ] End-to-end: needs `APK_PIN_PUSH_TOKEN` added to the repository, then a
      real Renovate `ALPINE_VERSION` pull request to exercise the workflow
      live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic resolution and updating of Alpine APK version pins when Alpine versions change.
  * Added safeguards to validate versions, package availability, configuration values, and permitted pin updates.

* **Documentation**
  * Updated environment configuration and project guidance to explain automatic APK pin resolution and its limitations.

* **Tests**
  * Added coverage for APK version parsing, precision handling, configuration updates, invalid inputs, missing packages, and rejected changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->