### PR TITLE
fix: retrigger PR validation via workflow_dispatch instead of a stored PAT

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -11,6 +11,16 @@ on:
   # commit; ported ahead of need, alongside coderabbit-gate.yml, so that gap
   # cannot reopen later.
   merge_group:
+  # resolve-apk-pins.yml pushes its own commit onto a Renovate pull request
+  # with GITHUB_TOKEN, which GitHub's anti-recursion rule keeps from starting
+  # a new `pull_request: synchronize` run here; an explicit workflow_dispatch
+  # call is exempt from that rule, which is what that workflow uses this
+  # trigger for, right after its push, to get `Tests` to run against the new
+  # commit the normal way. No inputs: none of the jobs below read
+  # `github.event.pull_request.*` for their actual logic, only `actions/checkout`
+  # (which defaults to the ref that triggered the run either way), so
+  # `--ref <branch>` on the dispatch is sufficient on its own.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/resolve-apk-pins.yml
+++ b/.github/workflows/resolve-apk-pins.yml
@@ -23,33 +23,44 @@ name: Resolve apk Pins
 # exact failure they were kept out of Renovate's hands to avoid in the first
 # place.
 #
-# Why GITHUB_TOKEN pushes the commit, and re-triggers Tests by hand:
+# Why GITHUB_TOKEN pushes the commit, and re-triggers the required checks by
+# hand:
 # GitHub does not start new workflow runs from a push authenticated with the
 # default GITHUB_TOKEN, specifically to stop workflows triggering each other
 # in a loop (the same restriction bot-auto-merge.yml's own comments rely on
 # for `workflow_run` over `status`). Left there, that would leave the
-# resolver's commit sitting on the pull request with `Tests` never re-run
-# against it, which fails the one requirement this workflow cannot compromise
-# on: "don't build a parallel test path", the real `Tests` job in
-# pull-request-validation.yml has to grade this commit the normal way.
+# resolver's commit sitting on the pull request with none of `Tests`, `Pin
+# Only` or `Review Verified` ever re-run against it, which fails the one
+# requirement this workflow cannot compromise on: "don't build a parallel
+# test or review path", the real jobs that publish those three have to grade
+# this commit the normal way.
 #
 # The anti-recursion rule has one documented exception: an explicit
 # `workflow_dispatch` call made through the API is exempt even when made with
 # GITHUB_TOKEN, because that call is the workflow deliberately asking for
 # another run rather than a push incidentally causing one. So instead of a
-# stored credential whose only job is to look like a human push,
-# `pull-request-validation.yml` carries a `workflow_dispatch` trigger and,
-# right after the push below lands, the "Re-trigger pull request validation"
-# step calls `gh workflow run pull-request-validation.yml --ref
-# "$HEAD_REF"` to start a `Tests` run against the branch's new tip directly.
-# That call needs `actions: write`, granted below, the same way the push
-# needs `contents: write`; both are GITHUB_TOKEN, scoped down to this job,
-# with no separate secret to create, rotate or lose.
+# stored credential whose only job is to look like a human push, the "Re-
+# trigger pull request validation" and "Re-trigger the CodeRabbit gate"
+# steps, right after the push below lands, dispatch the two workflows that
+# publish those three checks directly:
+#
+#   - `pull-request-validation.yml` carries a `workflow_dispatch` trigger
+#     (added alongside this change) for `Pre-commit` and `Tests`.
+#   - `coderabbit-gate.yml` already had one, `pr_number`, its own "manual
+#     recovery path" for a pull request stuck with a stale or missing
+#     verdict; this reuses it rather than adding a second mechanism, for
+#     `Pin Only` and `Review Verified`. Finishing that run also fires
+#     bot-auto-merge.yml's `workflow_run` trigger, which is what actually
+#     supplies the approval once every required check reads green.
+#
+# Both calls need `actions: write`, granted below, the same way the push
+# needs `contents: write`; all three are GITHUB_TOKEN, scoped down to this
+# job, with no separate secret to create, rotate or lose.
 #
 # Branch protection matches a required check by name and by the commit SHA
 # the check run reports against, not by which event produced the run, so a
-# `Tests` run started this way satisfies the pull request's requirement for
-# its head SHA exactly as a `pull_request: synchronize`-triggered one would.
+# check run started this way satisfies the pull request's requirement for
+# its head SHA exactly as one from the ordinary trigger would.
 #
 # The failure mode this is defensively built around: Renovate's default
 # `rebaseWhen` can rebase or recreate its branch on its own (a later daily
@@ -72,9 +83,10 @@ name: Resolve apk Pins
 # the same anti-recursion rule described above, just working in this
 # workflow's favor instead of against it this time. There is no second run of
 # this workflow to reason about after a self-push, and so no loop to guard
-# against; the `workflow_dispatch` re-trigger a few paragraphs up is a
-# narrower, explicit ask of one specific workflow (`pull-request-validation.yml`),
-# not a broad synchronize this workflow would otherwise also react to.
+# against; the two `workflow_dispatch` re-triggers a few paragraphs up are a
+# narrower, explicit ask of two specific workflows
+# (`pull-request-validation.yml` and `coderabbit-gate.yml`), not a broad
+# synchronize this workflow itself would otherwise also react to.
 on:
   # zizmor: ignore[dangerous-triggers]
   #
@@ -255,16 +267,18 @@ jobs:
           # contents: write permission (above) is all this needs, and this
           # is exactly the push the header comment says will not retrigger
           # this workflow.
-          # That is fine: the "Re-trigger pull request validation" step below
-          # is what starts `Tests` against this new commit, not this push.
+          # That is fine: the two "Re-trigger" steps below are what start
+          # `Tests`, `Pin Only` and `Review Verified` against this new
+          # commit, not this push.
           git push \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
             "HEAD:refs/heads/${HEAD_REF}"
 
       - name: Re-trigger pull request validation
         # A push authenticated with GITHUB_TOKEN, the one above, does not
-        # start a new workflow run; only this explicit workflow_dispatch call
-        # does, see the header comment. `--ref` is enough: none of
+        # start a new workflow run at all, for any workflow, on any trigger:
+        # only an explicit workflow_dispatch call does, see the header
+        # comment. `--ref` is enough for this one: none of
         # pull-request-validation.yml's jobs read `github.event.pull_request.*`
         # for their actual test logic (verified by reading that workflow
         # file), they only need the branch checked out, which
@@ -281,3 +295,37 @@ jobs:
           gh workflow run pull-request-validation.yml \
             --repo "$REPO" \
             --ref "$HEAD_REF"
+
+      - name: Re-trigger the CodeRabbit gate
+        # `Tests` is not the only required check the suppressed push leaves
+        # stale: `Pin Only` and `Review Verified` are published by
+        # coderabbit-gate.yml, which only regrades a pull request on its own
+        # pull_request_target/status/schedule/merge_group triggers, none of
+        # which the push above fires either. Left alone, both statuses would
+        # sit at whatever they last read for the pull request's previous
+        # head, never republished for the commit this workflow just pushed,
+        # so the pull request could never actually satisfy its required
+        # checks for its new head SHA.
+        #
+        # coderabbit-gate.yml already has a workflow_dispatch input built for
+        # exactly this: `pr_number`, its own "manual recovery path" for a
+        # pull request stuck with a stale or missing verdict (see that
+        # workflow's header comment). It never checks out the pull request's
+        # branch, only reads its number, metadata and diff through the API,
+        # so this call dispatches the default branch's copy of the workflow,
+        # not `$HEAD_REF`, and passes the pull request number instead.
+        # Finishing this run also fires bot-auto-merge.yml's own
+        # `workflow_run` trigger, which is what actually supplies the
+        # approval once every required check reads green; nothing further
+        # needs to be dispatched for that to happen.
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run coderabbit-gate.yml \
+            --repo "$REPO" \
+            --field "pr_number=$PR_NUMBER"

--- a/.github/workflows/resolve-apk-pins.yml
+++ b/.github/workflows/resolve-apk-pins.yml
@@ -23,23 +23,33 @@ name: Resolve apk Pins
 # exact failure they were kept out of Renovate's hands to avoid in the first
 # place.
 #
-# Why a personal access token, not GITHUB_TOKEN, pushes the commit:
+# Why GITHUB_TOKEN pushes the commit, and re-triggers Tests by hand:
 # GitHub does not start new workflow runs from a push authenticated with the
 # default GITHUB_TOKEN, specifically to stop workflows triggering each other
 # in a loop (the same restriction bot-auto-merge.yml's own comments rely on
-# for `workflow_run` over `status`). Pushing with GITHUB_TOKEN would leave the
+# for `workflow_run` over `status`). Left there, that would leave the
 # resolver's commit sitting on the pull request with `Tests` never re-run
 # against it, which fails the one requirement this workflow cannot compromise
 # on: "don't build a parallel test path", the real `Tests` job in
 # pull-request-validation.yml has to grade this commit the normal way.
-# APK_PIN_PUSH_TOKEN is a fine-grained personal access token, scoped to
-# Contents: write on this repository only, the same shape as
-# CODERABBIT_NUDGE_TOKEN in coderabbit-review-queue.yml and for the same
-# underlying reason: a push authenticated as an account is what GitHub
-# actually re-triggers workflows from. If that secret is ever missing or
-# revoked, the push step below fails loudly with a 401 or 403; there is no
-# silent fallback to GITHUB_TOKEN, the same posture coderabbit-review-queue.yml
-# takes for its own PAT.
+#
+# The anti-recursion rule has one documented exception: an explicit
+# `workflow_dispatch` call made through the API is exempt even when made with
+# GITHUB_TOKEN, because that call is the workflow deliberately asking for
+# another run rather than a push incidentally causing one. So instead of a
+# stored credential whose only job is to look like a human push,
+# `pull-request-validation.yml` carries a `workflow_dispatch` trigger and,
+# right after the push below lands, the "Re-trigger pull request validation"
+# step calls `gh workflow run pull-request-validation.yml --ref
+# "$HEAD_REF"` to start a `Tests` run against the branch's new tip directly.
+# That call needs `actions: write`, granted below, the same way the push
+# needs `contents: write`; both are GITHUB_TOKEN, scoped down to this job,
+# with no separate secret to create, rotate or lose.
+#
+# Branch protection matches a required check by name and by the commit SHA
+# the check run reports against, not by which event produced the run, so a
+# `Tests` run started this way satisfies the pull request's requirement for
+# its head SHA exactly as a `pull_request: synchronize`-triggered one would.
 #
 # The failure mode this is defensively built around: Renovate's default
 # `rebaseWhen` can rebase or recreate its branch on its own (a later daily
@@ -55,12 +65,16 @@ name: Resolve apk Pins
 # nothing (`scripts/resolve-apk-pins.py` is idempotent by construction: it
 # only ever writes a value that differs from what is already there). Either
 # way the branch converges back to "every apk pin matches the ALPINE_VERSION
-# it carries" without anyone having to notice the rebase happened. The one
-# thing this does not need is a special case for "my own push retriggered
-# me": that push is authenticated with the PAT rather than GITHUB_TOKEN
-# specifically so it does retrigger, and the second run's own recomputation
-# finding nothing to change is what stops that from looping, not a guard
-# against running twice.
+# it carries" without anyone having to notice the rebase happened. That
+# `synchronize` has to be a genuine push from Renovate's own bot identity,
+# not from GITHUB_TOKEN: this workflow's own commit below is pushed with
+# GITHUB_TOKEN precisely so it does not retrigger `pull_request_target` here,
+# the same anti-recursion rule described above, just working in this
+# workflow's favor instead of against it this time. There is no second run of
+# this workflow to reason about after a self-push, and so no loop to guard
+# against; the `workflow_dispatch` re-trigger a few paragraphs up is a
+# narrower, explicit ask of one specific workflow (`pull-request-validation.yml`),
+# not a broad synchronize this workflow would otherwise also react to.
 on:
   # zizmor: ignore[dangerous-triggers]
   #
@@ -83,8 +97,9 @@ on:
     paths:
       - ".env.example"
 
-# The floor. Nothing here needs contents: write from GITHUB_TOKEN: the commit
-# is pushed with APK_PIN_PUSH_TOKEN instead, see the header above.
+# The floor. The job below grants itself contents: write and actions: write
+# on GITHUB_TOKEN explicitly, scoped to that one job rather than raised here,
+# see the header above for why both are needed.
 permissions:
   contents: read
 
@@ -102,19 +117,25 @@ jobs:
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # One at a time per pull request. Renovate's own rebase and this
-    # workflow's own follow-up push can both produce a `synchronize` in quick
-    # succession; two overlapping runs computing against two different heads
-    # and racing to push would be exactly the pile-up bot-auto-merge.yml's
-    # concurrency groups exist to prevent, for the same reason. Queued rather
-    # than cancelled: a superseded run has nothing worth cancelling towards,
-    # but a cancelled one might have been the run that would have pushed the
-    # correct fix for the head that mattered.
+    # One at a time per pull request. Renovate can push more than once in
+    # quick succession on its own (a rebase landing moments after the
+    # original open, say), each a genuine `synchronize`; two overlapping runs
+    # computing against two different heads and racing to push would be
+    # exactly the pile-up bot-auto-merge.yml's concurrency groups exist to
+    # prevent, for the same reason. This workflow's own commit below no
+    # longer adds to that risk, since it pushes with GITHUB_TOKEN and does not
+    # produce a `synchronize` this workflow reacts to (see the header above),
+    # but the concurrency group still guards against Renovate's own
+    # back-to-back pushes. Queued rather than cancelled: a superseded run has
+    # nothing worth cancelling towards, but a cancelled one might have been
+    # the run that would have pushed the correct fix for the head that
+    # mattered.
     concurrency:
       group: resolve-apk-pins-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
-      contents: read
+      contents: write
+      actions: write
     steps:
       - name: Check out the default branch
         # Explicit, and load-bearing: this is what makes scripts/resolve-apk-pins.py
@@ -203,7 +224,7 @@ jobs:
       - name: Commit and push if anything resolved differently
         if: steps.resolve.outputs.changed == 'true'
         env:
-          APK_PIN_PUSH_TOKEN: ${{ secrets.APK_PIN_PUSH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           ALPINE_VERSION: ${{ steps.fetch.outputs.alpine_version }}
@@ -211,15 +232,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "$APK_PIN_PUSH_TOKEN" ]; then
-            echo "::error::APK_PIN_PUSH_TOKEN is not set. A fine-grained personal" \
-              "access token with Contents: write on this repository only is" \
-              "required so this push authenticates as something other than" \
-              "GITHUB_TOKEN and actually retriggers the pull request's required" \
-              "checks; see this workflow's header comment."
-            exit 1
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .env.example
@@ -239,6 +251,33 @@ jobs:
           # current commit, plus the one just made on top of it, which is
           # exactly what makes this a fast-forward push rather than a rewrite
           # of history the pull request's other commits are sitting on.
+          # GITHUB_TOKEN, no stored credential involved. The job's own
+          # contents: write permission (above) is all this needs, and this
+          # is exactly the push the header comment says will not retrigger
+          # this workflow.
+          # That is fine: the "Re-trigger pull request validation" step below
+          # is what starts `Tests` against this new commit, not this push.
           git push \
-            "https://x-access-token:${APK_PIN_PUSH_TOKEN}@github.com/${REPO}.git" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
             "HEAD:refs/heads/${HEAD_REF}"
+
+      - name: Re-trigger pull request validation
+        # A push authenticated with GITHUB_TOKEN, the one above, does not
+        # start a new workflow run; only this explicit workflow_dispatch call
+        # does, see the header comment. `--ref` is enough: none of
+        # pull-request-validation.yml's jobs read `github.event.pull_request.*`
+        # for their actual test logic (verified by reading that workflow
+        # file), they only need the branch checked out, which
+        # `workflow_dispatch` does the same way `pull_request` does, so no
+        # input parameters are needed here.
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run pull-request-validation.yml \
+            --repo "$REPO" \
+            --ref "$HEAD_REF"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,16 +76,24 @@ matches, which would put these seven right back under Renovate's independent
 tracking, the failure mode they are excluded from Renovate to avoid in the
 first place.
 
-The commit is pushed with a personal access token (`APK_PIN_PUSH_TOKEN`
-secret, fine-grained, `Contents: write` on this repository only), not
-`GITHUB_TOKEN`, the same reasoning as `CODERABBIT_NUDGE_TOKEN` in
-`coderabbit-review-queue.yml`: GitHub does not start new workflow runs from a
-push authenticated with the default `GITHUB_TOKEN`, specifically to prevent
-workflows retriggering each other in a loop, and this repository needs the
-opposite here. The whole point of pushing this commit is that
+The commit is pushed with `GITHUB_TOKEN` (the job grants itself `contents:
+write` for exactly this). GitHub does not start new workflow runs from a push
+authenticated with the default `GITHUB_TOKEN`, specifically to prevent
+workflows retriggering each other in a loop, so that push alone would leave
 `pull-request-validation.yml`'s real `Tests` job (`make build` plus the
-backup/restore roundtrip) grades it the normal way, and a `GITHUB_TOKEN`
-push would leave that job never re-run against it.
+backup/restore roundtrip) never re-run against it. The anti-recursion rule
+has one documented exception: an explicit `workflow_dispatch` call made
+through the API, even with `GITHUB_TOKEN`. `pull-request-validation.yml`
+carries a `workflow_dispatch` trigger for exactly this, and right after the
+push, `resolve-apk-pins.yml` calls `gh workflow run
+pull-request-validation.yml --ref <branch>` (needing `actions: write`) to
+start `Tests` against the new commit directly. Branch protection matches a
+required check by name and by the SHA it reports against, not by which event
+produced the run, so a `Tests` run started this way satisfies the pull
+request's requirement the same as a `synchronize`-triggered one would. No
+stored credential (no PAT like `CODERABBIT_NUDGE_TOKEN` in
+`coderabbit-review-queue.yml`) is needed for this one, since the retrigger is
+an explicit API call rather than a push that needs to look human-authored.
 
 Safe to re-run, including when Renovate's own `rebaseWhen` rebases or
 recreates its branch later and drops this workflow's commit the way any
@@ -166,9 +174,10 @@ a given Alpine release actually carries) that no author, human or bot, can
 know without querying it, and records the answer, the same category of
 automation Renovate and Dependabot already perform on this repository's
 behalf, just for the one datasource neither of them can model. Its checkout
-keeps `persist-credentials: false` too; the push instead uses
-`APK_PIN_PUSH_TOKEN`, a separate, narrowly-scoped credential, deliberately
-not `GITHUB_TOKEN`, for the reasons in that section above.
+keeps `persist-credentials: false` too; the push instead uses `GITHUB_TOKEN`
+with a job-scoped `contents: write`, plus an explicit `workflow_dispatch`
+re-trigger of `pull-request-validation.yml`, for the reasons in that section
+above.
 
 ### Branch, PR, gates, then merge
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,20 +80,29 @@ The commit is pushed with `GITHUB_TOKEN` (the job grants itself `contents:
 write` for exactly this). GitHub does not start new workflow runs from a push
 authenticated with the default `GITHUB_TOKEN`, specifically to prevent
 workflows retriggering each other in a loop, so that push alone would leave
-`pull-request-validation.yml`'s real `Tests` job (`make build` plus the
-backup/restore roundtrip) never re-run against it. The anti-recursion rule
-has one documented exception: an explicit `workflow_dispatch` call made
-through the API, even with `GITHUB_TOKEN`. `pull-request-validation.yml`
-carries a `workflow_dispatch` trigger for exactly this, and right after the
-push, `resolve-apk-pins.yml` calls `gh workflow run
-pull-request-validation.yml --ref <branch>` (needing `actions: write`) to
-start `Tests` against the new commit directly. Branch protection matches a
-required check by name and by the SHA it reports against, not by which event
-produced the run, so a `Tests` run started this way satisfies the pull
-request's requirement the same as a `synchronize`-triggered one would. No
-stored credential (no PAT like `CODERABBIT_NUDGE_TOKEN` in
-`coderabbit-review-queue.yml`) is needed for this one, since the retrigger is
-an explicit API call rather than a push that needs to look human-authored.
+none of the pull request's required checks re-run against it: not
+`pull-request-validation.yml`'s `Tests` job (`make build` plus the
+backup/restore roundtrip), and not `coderabbit-gate.yml`'s `Pin Only` and
+`Review Verified` either, since that workflow's own regrading triggers never
+fire from a GITHUB_TOKEN push any more than `pull-request-validation.yml`'s
+do. The anti-recursion rule has one documented exception: an explicit
+`workflow_dispatch` call made through the API, even with `GITHUB_TOKEN`.
+Right after the push, `resolve-apk-pins.yml` dispatches both workflows
+directly: `pull-request-validation.yml` carries a `workflow_dispatch` trigger
+added for this, invoked with `gh workflow run pull-request-validation.yml
+--ref <branch>`; `coderabbit-gate.yml` already had one, `pr_number`, its own
+manual recovery path for a pull request stuck with a stale verdict, invoked
+with `gh workflow run coderabbit-gate.yml --field pr_number=<number>`
+instead (both need `actions: write`). Finishing that second run also fires
+`bot-auto-merge.yml`'s own `workflow_run` trigger, which is what actually
+supplies the approval once every required check reads green. Branch
+protection matches a required check by name and by the SHA it reports
+against, not by which event produced the run, so a check run started this
+way satisfies the pull request's requirement the same as one from the
+ordinary trigger would. No stored credential (no PAT like
+`CODERABBIT_NUDGE_TOKEN` in `coderabbit-review-queue.yml`) is needed for
+this, since the retrigger is an explicit API call rather than a push that
+needs to look human-authored.
 
 Safe to re-run, including when Renovate's own `rebaseWhen` rebases or
 recreates its branch later and drops this workflow's commit the way any
@@ -109,9 +118,13 @@ comparing is what makes it not matter.
 `bot-auto-merge.yml` needed no change for this: `Pin Only` grades the pull
 request's cumulative diff (`gh pr diff`), not any one commit, so a second,
 workflow-authored commit on top of Renovate's own is graded the same as if
-it had all been one commit, and the approval job re-triggers correctly on
-the resolver's own `synchronize` event the same way it already does on any
-other push to the pull request.
+it had all been one commit. The approval job does not react to a
+`synchronize` from the resolver's own push, since that push is GITHUB_TOKEN
+and produces no such event; it reacts to `coderabbit-gate.yml`'s
+`workflow_run` finishing instead, the same `workflow_dispatch` re-trigger
+described above, and that is what actually re-derives `Pin Only` and `Review
+Verified` for the new commit and, once both read `success`, supplies the
+approval.
 
 Only these seven packages resolve automatically. A package newly added to
 the Dockerfile's `apk add` line still needs a person to decide its variable


### PR DESCRIPTION
## Summary

`resolve-apk-pins.yml` (from #47) pushed its apk-pin-resolution commit onto
a Renovate pull request using a fine-grained PAT (`APK_PIN_PUSH_TOKEN`),
solely because GitHub suppresses new workflow runs (including `pull_request:
synchronize`) triggered by a push authenticated with the default
`GITHUB_TOKEN`, and this workflow needs the pull request's `Tests` job to
re-run against the commit it just pushed.

GitHub's anti-recursion rule has a documented exception: an explicit
`workflow_dispatch` call made through the API is exempt from it even when
made with `GITHUB_TOKEN`. This replaces the PAT with that mechanism:

- The push now uses `GITHUB_TOKEN`, with the `resolve` job granting itself
  `contents: write` for it.
- `pull-request-validation.yml` gets a `workflow_dispatch:` trigger
  alongside its existing `pull_request:`/`merge_group:` triggers. No inputs:
  none of its jobs read `github.event.pull_request.*` for their actual test
  logic, they only need the branch checked out.
- Right after the push, `resolve-apk-pins.yml` calls `gh workflow run
  pull-request-validation.yml --ref "$HEAD_REF"` (needing `actions: write`)
  to start `Tests` against the pushed commit directly.
- All `APK_PIN_PUSH_TOKEN` references removed: the push step's PAT check and
  error message, its use as the git remote credential, and the workflow's
  header comment, which is rewritten to explain the new mechanism (the
  rebase-safety reasoning is preserved and adjusted where the mechanics
  actually changed: this workflow's own push no longer self-retriggers
  `pull_request_target` here, since it's GITHUB_TOKEN now, whereas a genuine
  Renovate rebase still does, since that's a real push from Renovate's own
  bot identity).
- `CLAUDE.md`'s documentation of this mechanism updated to match.

No secret needs to be created, rotated, or lost. Branch protection matches a
required check by name and by the commit SHA it reports against, not by
which event produced the run, so a `Tests` run started via
`workflow_dispatch` satisfies the pull request's requirement for its head
SHA the same as a `synchronize`-triggered one would.

## Test plan

- [x] `pre-commit run --all-files` passes (including zizmor and
      actionlint over the touched workflow files)
- [x] `pytest tests --verbose` passes (146 passed)
- [ ] Empirically confirm a `workflow_dispatch`-triggered `Tests` run
      reports against this PR's head SHA and is recognized as satisfying the
      required check (this PR doesn't touch `.env.example`'s
      `ALPINE_VERSION`, so `resolve-apk-pins.yml` won't fire on it directly;
      verifying via a manual `gh workflow run pull-request-validation.yml
      --ref <this-branch>` dispatch instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automation to use the built-in GitHub token for committing resolved APK pin updates.
  * Added explicit workflow triggers to re-run required validation and review checks after automated updates.
  * Removed reliance on a separately stored push credential.
  * Improved automated pull request validation and approval workflow coordination.

* **Documentation**
  * Updated workflow documentation to reflect the revised authentication, validation, and approval process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->