### PR TITLE
feat: publish the built image to GHCR on release

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,6 +9,7 @@
     "aports",
     "baselayout",
     "binsh",
+    "buildx",
     "charityware",
     "ciphertext",
     "cspell",

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -45,3 +45,37 @@ jobs:
           name: Release ${{ needs.create-tag.outputs.new_tag }}
           body: ${{ needs.create-tag.outputs.changelog }}
           allowUpdates: true
+
+  trigger-image-publish:
+    name: Trigger Image Publish
+    needs: [create-tag, create-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      # Explicit API dispatch, not a stored credential: the release above is
+      # created with the default GITHUB_TOKEN (no 'token:' override on
+      # ncipollo/release-action), and GitHub does not start new workflow runs
+      # from an event a GITHUB_TOKEN created, release creation included, to
+      # stop workflows retriggering each other in a loop. That would leave
+      # publish-image.yml's 'release: published' trigger permanently unfired
+      # for every release this workflow itself creates. The documented
+      # exception is an explicit workflow_dispatch call made through the API,
+      # even with GITHUB_TOKEN, which is exactly what this job makes,
+      # carrying the tag create-tag already minted so publish-image.yml never
+      # has to recompute it. Same shape as resolve-apk-pins.yml's own
+      # workflow_dispatch re-trigger of pull-request-validation.yml; see
+      # CLAUDE.md.
+      actions: write
+    steps:
+      - name: Dispatch publish-image.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.create-tag.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run publish-image.yml \
+            --repo "$REPO" \
+            --ref "$TAG" \
+            --field tag="$TAG" \
+            --field publish_latest=true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,236 @@
+name: Publish Image
+
+# Builds the Docker image and pushes it to
+# ghcr.io/ivan-pinatti-labs/rsync-crypt, tagged 'latest' and with the exact
+# semantic version merge.yml already minted for the release.
+#
+# Trigger: 'release: published', not a 'workflow_run' reacting to merge.yml
+# and not a raw tag push. merge.yml's own two jobs already do the two things
+# a trigger here would otherwise have to re-derive:
+#
+#   - create-tag (mathieudutour/github-tag-action) computes the next semver
+#     tag and creates the git tag.
+#   - create-release (ncipollo/release-action) turns that tag into a GitHub
+#     Release.
+#
+# 'release: published' fires once that second job finishes, and its payload
+# (github.event.release.tag_name) already carries the exact tag create-tag
+# minted, so this workflow never has to recompute a version itself. A
+# 'workflow_run' trigger watching merge.yml would still need something to
+# read the tag back out of the completed run (a second API call, or an
+# artifact create-tag never uploads), and it would fire even if
+# create-release's job failed after create-tag's succeeded, i.e. on a tag
+# with no release behind it. A raw tag push ('push: tags: v*') would fire a
+# commit earlier than 'release: published' does, before the release (and its
+# changelog body) exists at all, for no benefit here since nothing in this
+# workflow reads the release body. 'release: published' is therefore the one
+# trigger that names the finished artifact (the release) this workflow
+# actually republishes as an image, with no re-derivation and no ordering
+# gap.
+#
+# workflow_dispatch exists only to test this workflow itself (build, push,
+# verify) without waiting for a real release: it takes its own 'tag' input
+# rather than reading github.event.release.tag_name, which does not exist
+# outside a 'release' event.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Version tag to publish as the image tag, e.g. '0.0.0-test'. Only
+          used for a manual run; a real release always uses the release's own
+          tag_name instead.
+        required: true
+        default: "0.0.0-manual"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  IMAGE: ghcr.io/ivan-pinatti-labs/rsync-crypt
+
+jobs:
+  build-and-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    # amd64 alone builds in a couple of minutes; arm64 goes through QEMU
+    # emulation for every apk transaction the Dockerfile runs, which is
+    # noticeably slower for the same image. 30 minutes leaves headroom for
+    # that without masking a genuine hang.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # The only new permission this task needs. GITHUB_TOKEN scoped to
+      # packages: write on this job is sufficient to push to
+      # ghcr.io/ivan-pinatti-labs/rsync-crypt, which lives under this
+      # repository's own owner; no personal access token or other stored
+      # secret is required.
+      packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Determine the version tag
+        id: version
+        # github-tag-action's default tag_prefix is 'v' and merge.yml does not
+        # override it, so github.event.release.tag_name arrives as 'vX.Y.Z'.
+        # The image tag drops the 'v': published tags here read '1.2.0', not
+        # 'v1.2.0'.
+        #
+        # Both untrusted values are passed through env: rather than
+        # interpolated directly into the script, so a release tag or a
+        # workflow_dispatch input crafted as shell syntax is read as an inert
+        # string, not executed.
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="$RELEASE_TAG_NAME"
+          else
+            tag="$DISPATCH_TAG"
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::No version tag resolved from the triggering event."
+            exit 1
+          fi
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Read apk version pins from .env.example
+        id: pins
+        # The Dockerfile's ARGs (ALPINE_VERSION, GOCRYPTFS_VERSION,
+        # BASH_VERSION, LESS_VERSION, OPENSSH_VERSION, RSYNC_VERSION,
+        # SSHFS_VERSION, VIM_VERSION) are exactly what the Makefile's 'build'
+        # target passes as --build-arg, all sourced from .env.example. Reading
+        # them straight out of that file, rather than re-deriving them or
+        # invoking 'make build' (which has no push or multi-arch support),
+        # keeps this workflow unable to drift from what a local 'make build'
+        # would produce.
+        run: |
+          set -euo pipefail
+          {
+            echo "build_args<<PINS_EOF"
+            for var in ALPINE_VERSION GOCRYPTFS_VERSION BASH_VERSION LESS_VERSION \
+              OPENSSH_VERSION RSYNC_VERSION SSHFS_VERSION VIM_VERSION; do
+              value=$(grep -m1 "^${var}=" .env.example | cut -d'=' -f2- | tr -d '"')
+              if [ -z "$value" ]; then
+                echo "::error::${var} missing or empty in .env.example."
+                exit 1
+              fi
+              echo "${var}=${value}"
+            done
+            echo "PINS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+        with:
+          platforms: arm64
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags and labels
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.version }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.pins.outputs.build_args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  verify:
+    name: Verify Published Image
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Read-only: this job only pulls what the previous job already pushed.
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull the published image by digest
+        # By digest, not by the 'latest' or version tag: a tag can move
+        # between the push above and this pull, a digest cannot, so this is
+        # proof the exact image just built is what gets verified.
+        env:
+          DIGEST: ${{ needs.build-and-push.outputs.digest }}
+        run: docker pull "${{ env.IMAGE }}@${DIGEST}"
+
+      # Same checks tests/test_build.py runs against a locally built image
+      # (test_required_binary_is_present, test_entrypoint_is_gocryptfs,
+      # test_image_runs_as_the_crypt_user), reused here directly against the
+      # freshly pushed GHCR image rather than pointed at through pytest: that
+      # suite's 'image' fixture builds locally via 'make build' and has no
+      # existing seam for a pre-built remote ref, and duplicating its handful
+      # of docker run assertions here is simpler than adding one.
+      - name: Verify required binaries are present
+        env:
+          DIGEST: ${{ needs.build-and-push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for binary in gocryptfs rsync sshfs fusermount ssh sshd; do
+            docker run --rm --entrypoint /bin/bash \
+              "${{ env.IMAGE }}@${DIGEST}" \
+              -c "command -v ${binary}"
+          done
+
+      - name: Verify the entrypoint is gocryptfs and starts without error
+        env:
+          DIGEST: ${{ needs.build-and-push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          entrypoint=$(docker inspect -f '{{json .Config.Entrypoint}}' "${{ env.IMAGE }}@${DIGEST}")
+          case "$entrypoint" in
+            *gocryptfs*) ;;
+            *)
+              echo "::error::Entrypoint is not gocryptfs: $entrypoint"
+              exit 1
+              ;;
+          esac
+          docker run --rm --entrypoint /usr/bin/gocryptfs "${{ env.IMAGE }}@${DIGEST}" -version
+
+      - name: Verify the image runs as the crypt user
+        env:
+          DIGEST: ${{ needs.build-and-push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          resolved=$(docker run --rm --entrypoint id "${{ env.IMAGE }}@${DIGEST}" -un)
+          [ "$resolved" = "crypt" ]

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,10 +28,26 @@ name: Publish Image
 # actually republishes as an image, with no re-derivation and no ordering
 # gap.
 #
-# workflow_dispatch exists only to test this workflow itself (build, push,
-# verify) without waiting for a real release: it takes its own 'tag' input
-# rather than reading github.event.release.tag_name, which does not exist
-# outside a 'release' event.
+# It is also, on its own, a trigger that never fires for the release
+# merge.yml actually creates. create-release calls ncipollo/release-action
+# with no 'token:' override, so it defaults to GITHUB_TOKEN, and GitHub does
+# not start new workflow runs from an event a GITHUB_TOKEN created, release
+# creation through the API included, specifically to stop workflows
+# triggering each other in a loop. This is the exact same restriction
+# CLAUDE.md documents for resolve-apk-pins.yml's push, and the fix is the
+# same shape: merge.yml's own 'trigger-image-publish' job explicitly
+# dispatches this workflow right after create-release finishes, via
+# 'gh workflow run publish-image.yml --field tag=<tag> --field
+# publish_latest=true' (needs 'actions: write', not a stored credential).
+# 'release: published' is left in place regardless, for the one case that
+# dispatch cannot cover: a release published by hand, or by a real user
+# token, through the GitHub UI or API rather than by merge.yml.
+#
+# workflow_dispatch exists for two things: it is what merge.yml's own dispatch
+# above rides on, and it is also how this workflow gets tested directly
+# (build, push, verify) without waiting for a real release. Either way it
+# takes its own 'tag' input rather than reading github.event.release.tag_name,
+# which does not exist outside a 'release' event.
 on:
   release:
     types: [published]
@@ -39,11 +55,21 @@ on:
     inputs:
       tag:
         description: >-
-          Version tag to publish as the image tag, e.g. '0.0.0-test'. Only
-          used for a manual run; a real release always uses the release's own
-          tag_name instead.
+          Version tag to publish as the image tag, e.g. '0.0.0-test'. A real
+          release always uses the release's own tag_name when triggered
+          natively; merge.yml's dispatch passes this explicitly instead,
+          since GITHUB_TOKEN release creation carries no event of its own to
+          read a tag_name from (see the comment above).
         required: true
         default: "0.0.0-manual"
+      publish_latest:
+        description: >-
+          Also push the ':latest' tag. merge.yml's dispatch sets this for a
+          genuine release; leave it false for an ad hoc manual test so a
+          throwaway tag never clobbers ':latest'.
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,6 +99,7 @@ jobs:
       packages: write
     outputs:
       version: ${{ steps.version.outputs.version }}
+      publish_latest: ${{ steps.version.outputs.publish_latest }}
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
@@ -92,20 +119,25 @@ jobs:
         # workflow_dispatch input crafted as shell syntax is read as an inert
         # string, not executed.
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           DISPATCH_TAG: ${{ inputs.tag }}
+          DISPATCH_PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "release" ]; then
+          if [ "$EVENT_NAME" = "release" ]; then
             tag="$RELEASE_TAG_NAME"
+            publish_latest=true
           else
             tag="$DISPATCH_TAG"
+            publish_latest="$DISPATCH_PUBLISH_LATEST"
           fi
           if [ -z "$tag" ]; then
             echo "::error::No version tag resolved from the triggering event."
             exit 1
           fi
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "publish_latest=$publish_latest" >> "$GITHUB_OUTPUT"
 
       - name: Read apk version pins from .env.example
         id: pins
@@ -153,8 +185,12 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
+          # 'latest' is enabled for a native 'release' event and for
+          # merge.yml's dispatch (which passes publish_latest=true), and
+          # disabled for an ad hoc manual workflow_dispatch test run, so a
+          # throwaway test tag is never mistaken for the current release.
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ steps.version.outputs.publish_latest == 'true' }}
             type=raw,value=${{ steps.version.outputs.version }}
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-image.yml`, building and pushing `ghcr.io/ivan-pinatti-labs/rsync-crypt` tagged `latest` and the release's own semver (the `v` prefix `mathieudutour/github-tag-action` mints is stripped for the image tag, e.g. release `v1.4.0` publishes as `1.4.0`).
- Auth is `GITHUB_TOKEN` with `packages: write` granted to just that job, via `docker/login-action` against `ghcr.io`. No new secret.
- Build args (`ALPINE_VERSION`, `GOCRYPTFS_VERSION`, `BASH_VERSION`, `LESS_VERSION`, `OPENSSH_VERSION`, `RSYNC_VERSION`, `SSHFS_VERSION`, `VIM_VERSION`) are read straight out of `.env.example`, the same source `make build` already reads, rather than re-derived.
- Multi-arch via buildx: `linux/amd64` and `linux/arm64`. Since the Dockerfile is `apk add` only (no compilation), the emulated `arm64` leg added negligible time in the real run below; both platforms ship.
- GitHub Actions cache (`cache-from`/`cache-to: type=gha`) for the build layers.
- A second `verify` job pulls the just-pushed image back by digest (not by a tag that could move) and checks the same things `tests/test_build.py` checks against a local build: the required binaries (`gocryptfs`, `rsync`, `sshfs`, `fusermount`, `ssh`, `sshd`), the `gocryptfs` entrypoint, and that the image runs as the `crypt` user.
- `merge.yml` gets a new `trigger-image-publish` job (see "Why the trigger needed a second piece" below).

## Why `release: published` over `workflow_run` or a tag push

`merge.yml` already does the two things a trigger here would otherwise have to re-derive: `create-tag` mints the semver tag, `create-release` turns it into a GitHub Release. `release: published` fires once that finishes, and its payload already carries the exact tag (`github.event.release.tag_name`), so nothing here recomputes a version. A `workflow_run` watching `merge.yml` would still need a second API call to read the tag back out, and would fire even if `create-release` failed after `create-tag` succeeded (a tag with no release). A raw tag push fires earlier, before the release exists, for no benefit since nothing here reads the release body. `release: published` names the one artifact this workflow actually republishes as an image.

## Why the trigger needed a second piece (CodeRabbit's catch)

CodeRabbit's review of the first commit caught that `release: published` alone would **never fire** for the releases `merge.yml` actually creates: `create-release` uses the default `GITHUB_TOKEN` (no `token:` override on `ncipollo/release-action`), and GitHub does not start new workflow runs from an event a `GITHUB_TOKEN` created, release creation through the API included, specifically to stop workflows retriggering each other in a loop. This is the exact same restriction `resolve-apk-pins.yml` already works around (see CLAUDE.md). Fix: a new `trigger-image-publish` job in `merge.yml`, needing only a job-scoped `actions: write`, explicitly dispatches `publish-image.yml` right after `create-release` finishes via `gh workflow run publish-image.yml --field tag=<tag> --field publish_latest=true`. `release: published` stays as the trigger too, for the one case the dispatch can't cover: a release published by hand or by a real user token.

CodeRabbit also caught that an ad hoc manual `workflow_dispatch` test run would have pushed `:latest`, clobbering the real tag. Fixed by gating `latest` on `publish_latest` (true for a native `release` event or `merge.yml`'s dispatch, false by default for a manual test).

## Verified live, end to end

Once this merged, `merge.yml` ran for real on `main`, minted `v1.4.0`, and its new `trigger-image-publish` job dispatched `publish-image.yml`, which:

- Built and pushed both platforms (`linux/amd64`, `linux/arm64`) in well under a minute for the "Build and Push" job.
- The `verify` job pulled the pushed image back by digest and confirmed all required binaries, the `gocryptfs` entrypoint, and the `crypt` user, all green: <https://github.com/ivan-pinatti-labs/rsync-crypt/actions/runs/33836788264>
- Pushed tags: `ghcr.io/ivan-pinatti-labs/rsync-crypt:latest` and `:1.4.0`.

One follow-up worth knowing about: the GHCR package is private by default (pushing with `GITHUB_TOKEN` doesn't change package visibility; that's a separate one-time toggle in the package's own settings, only available to the maintainer). `docker pull` without authentication currently fails with `unauthorized`. Flagging it here rather than changing it myself, since visibility is a deliberate maintainer decision, not part of this task's scope.

## Test plan

- [x] `pre-commit run --all-files` passes (yamllint, actionlint, zizmor, cspell, editorconfig-checker all clean).
- [x] CodeRabbit reviewed both commits; both actionable findings fixed and verified live.
- [x] Merged, and the real `merge.yml` → `publish-image.yml` chain ran end to end successfully on `main` (release `v1.4.0`), multi-arch, cache, and verify job all green.