### PR TITLE
docs: rename Docker Build to Docker Hub Probe and refresh its rationale

### DIFF
--- a/.github/workflows/coderabbit-review-queue.yml
+++ b/.github/workflows/coderabbit-review-queue.yml
@@ -74,9 +74,10 @@ jobs:
           # docker-torrent-box-with-vpn's `Code Check`, `Prerequisite Checks`
           # and `Detect Changed Paths`: there is no path filtering and no
           # integration suite here, so there is nothing else to name.
-          # `Docker Build` is deliberately left out too: it is not a required
-          # check (see docs/MERGE_PIPELINE.md), so a pull request is never
-          # blocked on it and there is nothing for a nudge to wait on there.
+          # `Docker Hub Probe` is deliberately left out too: it is not a
+          # required check (see docs/MERGE_PIPELINE.md), so a pull request is
+          # never blocked on it and there is nothing for a nudge to wait on
+          # there.
           OTHER_REQUIRED_CONTEXTS: "Pre-commit,Tests"
         shell: bash
         run: |

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -70,25 +70,38 @@ jobs:
       - name: Run tests
         run: pytest tests --verbose
 
-  docker-build:
-    name: Docker Build
+  docker-hub-probe:
+    name: Docker Hub Probe
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Not a required check yet, see docs/MERGE_PIPELINE.md. The `tests` job
-    # above already builds this exact image, through `make build`, as part of
-    # covering test_build.py's `image` fixture, so this job is not closing a
-    # gap in what gets exercised. It exists for two separate reasons instead:
+    # Not a build-verification job and not a required check, see
+    # docs/MERGE_PIPELINE.md. `Tests` above already builds this exact image,
+    # through `make build`, as part of covering test_build.py's `image`
+    # fixture, always as an anonymous pull, so this job is not closing a gap
+    # in what gets built or exercised. Its actual purpose is narrower: it is
+    # a live probe of the one pull path `Tests` never touches at all, the
+    # credentialed one, so a contributor reading only the name should not
+    # assume this job re-verifies anything `Tests` already covers.
     #
-    #   - The Dockerfile has never had a build attempted outside of a test
-    #     run, with a stand-alone Docker Hub login in front of it, which
-    #     means nothing in this repository has ever proven that the pull it
-    #     depends on (`FROM alpine:${ALPINE_VERSION}`) survives whatever rate
-    #     limiting a login is meant to avoid.
-    #   - It is the instrument for a question the transfer itself cannot
-    #     answer in advance: whether repository secrets survive a transfer to
-    #     an organization. GitHub's own transfer documentation does not say,
-    #     so this job is what will be watched, before and after that
-    #     transfer, once DOCKERHUB_USERNAME and DOCKERHUB_TOKEN exist.
+    # DOCKERHUB_USERNAME and DOCKERHUB_TOKEN exist on this repository (added
+    # 2026-08-26, ahead of the personal-account-to-organization transfer
+    # docs/MERGE_PIPELINE.md's "What the transfer silently changed" section
+    # describes). That transfer has since completed, and Actions secrets by
+    # name are confirmed, in that section, to have survived it, so the
+    # original one-time question this job was stood up to answer, "do
+    # repository secrets survive the transfer," is already settled. What the
+    # job still does, every pull request, is genuinely ongoing rather than
+    # historical:
+    #
+    #   - It is the only place `docker login docker.io` is attempted, so it
+    #     is what would first notice DOCKERHUB_USERNAME or DOCKERHUB_TOKEN
+    #     going stale, rotated, or revoked, long after the transfer that
+    #     motivated adding them.
+    #   - It is the only place `FROM alpine:${ALPINE_VERSION}` is pulled
+    #     authenticated rather than anonymous. `Tests`'s own `make build`
+    #     never logs in, so this is the sole exercise of the
+    #     credential-boosted pull path and its higher rate limit, distinct
+    #     from the always-anonymous pull `Tests` performs.
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -96,13 +109,14 @@ jobs:
           persist-credentials: false
 
       - name: Log in to Docker Hub
-        # These two secrets do not exist on this repository yet; the owner
-        # adds them separately. Until then this step has nothing to log in
-        # with and has to say so and move on rather than fail the job, the
-        # same way integration-tests.yml handles a fork's missing credentials
-        # in docker-torrent-box-with-vpn: an absent secret is not a build
-        # failure, it is just an anonymous pull, and Docker Hub allows those,
-        # rate limited rather than refused.
+        # DOCKERHUB_USERNAME and DOCKERHUB_TOKEN exist on this repository
+        # (see the job comment above), so this branch is not the normal
+        # path. It stays as a graceful fallback rather than a hard failure
+        # for the day either secret is removed or revoked: an absent secret
+        # is not a build failure, it is just an anonymous pull, and Docker
+        # Hub allows those, rate limited rather than refused, the same way
+        # integration-tests.yml handles a fork's missing credentials in
+        # docker-torrent-box-with-vpn.
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -181,12 +181,19 @@ same reason as in the sibling repository: a status a workflow chooses whether
 to write, and what to write, does not read as passed merely because it was
 skipped.
 
-`Docker Build`, also a job in `pull-request-validation.yml`, is deliberately
-not in this table. It builds the Dockerfile standalone and, once
-`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` exist, logs into Docker Hub before
-doing it, which is the probe for whether those secrets survive a future
-repository transfer. It is not required, and nothing in this pipeline waits
-on it.
+`Docker Hub Probe`, also a job in `pull-request-validation.yml`, is
+deliberately not in this table. It is not a second build-verification job:
+`Tests` above already builds this exact image through `make build`, always
+as an anonymous pull. `Docker Hub Probe` logs into Docker Hub with
+`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` before building, which is the only
+place either the credentialed pull path or those two secrets themselves are
+exercised. It was stood up to answer whether those secrets would survive the
+transfer to an organization described below; the transfer has since
+completed and "What the transfer silently changed" confirms Actions secrets
+did survive it by name, so that original question is settled. What the job
+still does on every pull request is catch the secrets going stale, rotated,
+or revoked at any later point, which is an ongoing concern, not a one-time
+one. It is not required, and nothing in this pipeline waits on it.
 
 ## `Review Verified`, and the bug it exists to fix
 


### PR DESCRIPTION
## Summary

- The `Docker Build` job in `pull-request-validation.yml` had accumulated stale framing: its comment said `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` "do not exist on this repository yet" and framed the whole job around a still-future org transfer. Neither is true anymore: both secrets were added 2026-08-26 and the transfer to `ivan-pinatti-labs` completed shortly after, with `docs/MERGE_PIPELINE.md`'s "What the transfer silently changed" already confirming Actions secrets survived it by name.
- Renamed the job to `Docker Hub Probe` and rewrote its header/step comments, the corresponding paragraph in `docs/MERGE_PIPELINE.md`, and the one reference to the old name in `coderabbit-review-queue.yml`, to state its actual ongoing purpose: `Tests` already builds the same image via `make build`, always as an anonymous pull, so this job isn't a second build-verification job. It's the *only* place the credentialed Docker Hub pull path and those two secrets get exercised at all, so its value now is catching the credentials going stale/rotated/revoked, an ongoing concern, not a settled one-time transfer question.
- Confirmed `Docker Build`/`Docker Hub Probe` is not a required check (branch protection lists only `Pre-commit`, `Tests`, `Pin Only`, `Review Verified`) and isn't referenced by any README badge, so the rename is safe.
- Considered folding this into `Tests` instead, but rejected it: `publish-image.yml` (merged since) pushes to GHCR with `secrets.GITHUB_TOKEN`, never touching Docker Hub, so it doesn't make this probe redundant. `Tests` never logs into Docker Hub either, so this remains the sole exercise of that credentialed path. Keeping it a separate, non-required job is deliberate: a Docker Hub credential problem shouldn't block a merge.

## Test plan

- [x] `pre-commit run --files .github/workflows/pull-request-validation.yml .github/workflows/coderabbit-review-queue.yml docs/MERGE_PIPELINE.md` passes locally (includes actionlint, zizmor, yamllint, markdownlint)
- [x] Confirmed via `gh api .../branches/main/protection` that the job is not in the required-checks list
- [x] Confirmed via `gh secret list` that `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` already exist
- [x] Grepped the repo for any other reference to the old `Docker Build` name or `docker-build` job id; none remain
- [ ] CI green on this PR (`Docker Hub Probe` job itself included)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Docker Hub Probe validates authenticated image pulls using configured credentials.
  * Documented that image build verification is handled separately by the existing test workflow.
  * Updated guidance to explain that the probe helps detect stale, rotated, or revoked credentials.

* **Chores**
  * Renamed the workflow job from “Docker Build” to “Docker Hub Probe” for clearer status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->