### PR TITLE
docs: fix cosign verify identity to match the release tag, not main

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,13 +301,16 @@ it stays true for the image you actually run next. See the
 [Releases](https://github.com/ivan-pinatti-labs/rsync-crypt/releases) page for
 the current version. Every image is signed with
 [cosign](https://github.com/sigstore/cosign) using GitHub Actions' keyless
-signing, so there is no private key to leak or rotate:
+signing, so there is no private key to leak or rotate. A real release signs
+with the identity of the git tag that triggered it (`refs/tags/vX.Y.Z`), not
+the `main` branch, so verification has to match the tag pattern rather than
+one fixed branch ref:
 
 ```bash
-IMAGE="ghcr.io/ivan-pinatti-labs/rsync-crypt:1.5.0"
+IMAGE="ghcr.io/ivan-pinatti-labs/rsync-crypt:1.5.2"
 
 cosign verify \
-  --certificate-identity "https://github.com/ivan-pinatti-labs/rsync-crypt/.github/workflows/publish-image.yml@refs/heads/main" \
+  --certificate-identity-regexp "^https://github\.com/ivan-pinatti-labs/rsync-crypt/\.github/workflows/publish-image\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   "$IMAGE"
 ```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -125,13 +125,15 @@ Every published image is signed with
 signing, so there is no private key to leak or rotate. The signature covers
 both registries, since they publish the same digest. Verify a pulled image
 actually came out of this repository's `publish-image.yml` workflow before
-trusting it:
+trusting it. A real release signs with the identity of the git tag that
+triggered it (`refs/tags/vX.Y.Z`), not the `main` branch, so verification has
+to match the tag pattern rather than one fixed branch ref:
 
 ```bash
 cosign verify \
-  --certificate-identity "https://github.com/ivan-pinatti-labs/rsync-crypt/.github/workflows/publish-image.yml@refs/heads/main" \
+  --certificate-identity-regexp "^https://github\.com/ivan-pinatti-labs/rsync-crypt/\.github/workflows/publish-image\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  ghcr.io/ivan-pinatti-labs/rsync-crypt:1.5.0
+  ghcr.io/ivan-pinatti-labs/rsync-crypt:1.5.2
 ```
 
 Prefer a pinned version tag over `latest` for anything unattended (a cron job,


### PR DESCRIPTION
## Summary

The README's cosign verify snippet used `--certificate-identity` with a fixed
`refs/heads/main` value. A real release actually signs with the git tag's ref
(`refs/tags/vX.Y.Z`), since `release: published` (or merge.yml's dispatch of
it) is what triggers `publish-image.yml`, not a push to `main`. The exact-match
identity never verified against any real published image.

## Fix

Switched to `--certificate-identity-regexp` matching the tag pattern, and
bumped the example tag to the current release.

## Test plan

Ran the corrected command directly against the live image:

```
cosign verify \
  --certificate-identity-regexp "^https://github\.com/ivan-pinatti-labs/rsync-crypt/\.github/workflows/publish-image\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  ghcr.io/ivan-pinatti-labs/rsync-crypt:1.5.2
```

Verified successfully. `pre-commit run --files README.md` passes clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated image verification instructions to reflect signing with the triggering release tag.
  * Updated the example image version from 1.5.0 to 1.5.2.
  * Revised certificate verification guidance to support versioned release tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->