### PR TITLE
fix: bust the apk layer cache on every published and nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -134,7 +134,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APK_CACHE_BUST=${{ github.run_id }}
+            APK_CACHE_BUST=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           sbom: true

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -117,12 +117,15 @@ jobs:
 
       - name: Build and push
         id: build
-        # No 'build-args:' input, same as publish-image.yml and for the same
-        # reason: every version this image is built from is an ARG default in
-        # the Dockerfile itself. This step forces the rebuild; the freshness
-        # comes entirely from the Dockerfile's own `apk update && apk
-        # upgrade` picking up whatever Alpine has published since the image
-        # was last built, not from any version bump here.
+        # No version pins in 'build-args:', same as publish-image.yml and for
+        # the same reason: every version this image is built from is an ARG
+        # default in the Dockerfile itself. APK_CACHE_BUST is the one
+        # build-arg passed here, and it is the entire point of this workflow:
+        # without it, 'cache-from: type=gha' below reuses the apk layer from
+        # the last build whenever the Dockerfile hasn't changed, which is
+        # every night, and this "nightly rebuild" would silently keep
+        # shipping whatever apk versions were current the first time it ran.
+        # See the ARG's own comment in the Dockerfile.
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -130,6 +133,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APK_CACHE_BUST=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           sbom: true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -383,20 +383,29 @@ jobs:
         # resolved version) already serializes runs, so two versions never
         # race to overwrite it at once.
         #
-        # No 'build-args:' input, deliberately. Every version this image is
-        # built from (ALPINE_VERSION, GOCRYPTFS_VERSION, BASH_VERSION,
-        # LESS_VERSION, OPENSSH_VERSION, RSYNC_VERSION, SSHFS_VERSION,
-        # VIM_VERSION) is an ARG default in the Dockerfile itself, kept
-        # correct by .github/workflows/resolve-apk-pins.yml on every
-        # ALPINE_VERSION bump, so passing them here would only be restating
-        # the file's own defaults back to it and creating a second place they
-        # could drift from. A preceding step used to read all eight out of
-        # .env.example for exactly that; it was removed with the pins.
+        # No version pins in 'build-args:', deliberately. Every version this
+        # image is built from (ALPINE_VERSION, GOCRYPTFS_VERSION,
+        # BASH_VERSION, LESS_VERSION, OPENSSH_VERSION, RSYNC_VERSION,
+        # SSHFS_VERSION, VIM_VERSION) is an ARG default in the Dockerfile
+        # itself, kept correct by .github/workflows/resolve-apk-pins.yml on
+        # every ALPINE_VERSION bump, so passing them here would only be
+        # restating the file's own defaults back to it and creating a second
+        # place they could drift from. A preceding step used to read all
+        # eight out of .env.example for exactly that; it was removed with
+        # the pins.
         #
         # This is also what keeps a published image identical to a local
         # 'make build': that target now passes a --build-arg only for a value
         # a user explicitly overrode on the command line, and passes none at
         # all by default, which is the same build this step performs.
+        #
+        # APK_CACHE_BUST is the one build-arg this step does pass, and it is
+        # not a version pin: it exists solely to defeat 'cache-from: type=gha'
+        # below on the Dockerfile's `apk update && apk upgrade` layer. See
+        # the ARG's own comment in the Dockerfile for why an unchanged
+        # Dockerfile otherwise cache-hits that layer and silently skips
+        # re-resolving apk packages, which is what shipped v1.6.0 with a
+        # week-old util-linux fix missing.
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -410,6 +419,8 @@ jobs:
           # org.opencontainers.image.version describe what this image *is*,
           # independent of which registry tags currently point at it.
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APK_CACHE_BUST=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Attaches a Software Bill of Materials and full (every

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -420,7 +420,7 @@ jobs:
           # independent of which registry tags currently point at it.
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APK_CACHE_BUST=${{ github.run_id }}
+            APK_CACHE_BUST=${{ github.run_id }}-${{ github.run_attempt }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Attaches a Software Bill of Materials and full (every

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,31 @@ ARG SSHFS_VERSION=3.7
 # apk-pin: resolved-from=ALPINE_VERSION
 ARG VIM_VERSION=9.2
 
+# BuildKit caches this RUN layer by its exact command text and build context,
+# with no notion that "apk upgrade" means something different today than it
+# did when the layer was last cached. A rebuild with an unchanged Dockerfile
+# (a scheduled nightly, or a release that bumps nothing in this file) hits
+# that cache and skips the layer entirely, silently shipping whatever apk
+# versions were current the last time it actually ran, not whatever Alpine
+# has published since. This is exactly what happened to v1.6.0: the layer
+# cache-hit in ~2 seconds (confirmed from the build log, far too fast for a
+# real apk fetch) and shipped util-linux 2.42.1-r0 days after Alpine's
+# security fix (2.42.3-r1) was already published.
+#
+# APK_CACHE_BUST breaks that cache hit on demand. It has no effect on the
+# packages installed; it only appears inside a `:` no-op so changing its
+# value changes the layer's cache key without changing what the command
+# does. `docker build .` and `make build` get the default (0) and keep
+# normal caching for fast local iteration. publish-image.yml and
+# nightly-build.yml pass a fresh value (the workflow run id) on every
+# invocation, so every published or nightly image re-resolves apk packages
+# against Alpine's live repo instead of trusting a cached layer's idea of
+# "current".
+ARG APK_CACHE_BUST=0
+
 RUN apk update \
     && apk upgrade \
+    && : "cache-bust=${APK_CACHE_BUST}" \
     && apk add --no-cache \
         bash~=${BASH_VERSION} \
         gocryptfs~=${GOCRYPTFS_VERSION} \


### PR DESCRIPTION
## What

The Dockerfile's `apk update && apk upgrade` layer was being cache-hit by BuildKit whenever the Dockerfile itself didn't change, silently skipping the fresh package resolution both `publish-image.yml` and `nightly-build.yml` depend on.

## Why this matters now

This is what broke v1.6.0's publish: the new Trivy gate (#58) correctly caught util-linux still on `2.42.1-r0` (days after Alpine published `2.42.3-r1`), because the apk layer cache-hit in ~2 seconds instead of actually re-resolving. The staging-tag design in #58 meant nothing public got pushed, so there's no registry drift, just a blocked release.

## Fix

Adds `APK_CACHE_BUST` as a Dockerfile ARG, referenced inertly inside the `apk update && apk upgrade` RUN so changing it busts only that layer's cache. `publish-image.yml` and `nightly-build.yml` now pass `${{ github.run_id }}` as its value, so every publish and nightly rebuild re-resolves apk packages against Alpine's live repo. Local `make build` / plain `docker build .` are unaffected (default 0, normal caching for fast iteration).

## Verified locally

- Same `APK_CACHE_BUST` value across two builds: full cache hit (confirmed via BuildKit's `CACHED` markers on every step).
- Different value: apk layer re-runs (no `CACHED` marker), and the resulting image has `libmount-2.42.3-r1` installed, the actual fix.
- `checklist-dev-docker` (hadolint) and `checklist-github-actions` (actionlint + zizmor) both pass on the changed files.

## After this merges

The auto-release bot will cut a new version off this `fix:` commit, which will re-run `publish-image.yml` and should finally promote and publish successfully. `v1.6.0`'s GitHub Release will remain without a published image behind it (nothing was ever pushed publicly for it); the next version supersedes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly and published container builds now refresh Alpine package information and updates on every run and retry.
  * Standard Docker builds continue to use existing layer caching for faster builds.
  * Automated container builds now support consistent cache invalidation while preserving normal caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->