### PR TITLE
fix: react to PR Validation finishing too, not only CodeRabbit Gate

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -77,25 +77,39 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
-  # For the owner's own path only. `Review Verified` is realistically the
-  # slowest of the four required contexts, since it depends on CodeRabbit's
-  # own review completing, and `pull_request_target` alone never fires again
-  # once a pull request stops changing, so without a second trigger a pull
-  # request whose review finished after the first poll window closed would
-  # need a push it did not otherwise need, just to get approved.
+  # For the owner's own path only. `pull_request_target` alone never fires
+  # again once a pull request stops changing, so without a second trigger a
+  # pull request whose last required context settled after the first poll
+  # window closed would need a push it did not otherwise need, just to get
+  # approved.
   #
-  # `workflow_run`, not `status`: `coderabbit-gate.yml` publishes
-  # `Review Verified` using `secrets.GITHUB_TOKEN`, and GitHub does not start
-  # new workflow runs from events a `GITHUB_TOKEN` creates, specifically to
-  # stop workflows triggering each other in a loop. A `status` trigger here
-  # would never fire from that publish at all, silently, which is a worse
-  # failure than the one it was meant to fix: at least a poll window closing
-  # fails this job closed and logs why. `workflow_run` is exempt from that
-  # restriction because it reacts to the run itself finishing, not to an API
-  # call a token made during it, which is why it exists as the sanctioned
-  # way to chain workflows without a personal access token.
+  # Both `CodeRabbit Gate` and `PR Validation` are named here, not just the
+  # first. `Review Verified` was assumed to be the slowest of the four
+  # required contexts, since it depends on CodeRabbit's own review
+  # completing, and that assumption held here, `Tests` runs as an ordinary
+  # job in the same push as `Pre-commit`, not gated behind a separate
+  # manual trigger. `docker-torrent-box-with-vpn` made the identical
+  # assumption with an integration suite gated behind `/run-tests`, and its
+  # own approve-owner job sat stuck on 2026-09-10 because nothing was
+  # listening for that suite finishing, only for CodeRabbit Gate. Nothing
+  # here has hit that failure mode, `Tests` finishing well ahead of a
+  # CodeRabbit review is still the normal case, but the fix costs nothing
+  # to carry over defensively: naming both workflows means whichever
+  # required context actually finishes last is what re-triggers the poll,
+  # instead of depending on an assumption about which one that will be.
+  #
+  # `workflow_run`, not `status`: both workflows publish their status using
+  # `secrets.GITHUB_TOKEN`, and GitHub does not start new workflow runs from
+  # events a `GITHUB_TOKEN` creates, specifically to stop workflows
+  # triggering each other in a loop. A `status` trigger here would never
+  # fire from either publish at all, silently, which is a worse failure
+  # than the one it was meant to fix: at least a poll window closing fails
+  # this job closed and logs why. `workflow_run` is exempt from that
+  # restriction because it reacts to the run itself finishing, not to an
+  # API call a token made during it, which is why it exists as the
+  # sanctioned way to chain workflows without a personal access token.
   workflow_run:
-    workflows: ["CodeRabbit Gate"]
+    workflows: ["CodeRabbit Gate", "PR Validation"]
     types: [completed]
 
 # The floor. Each job widens it for itself.


### PR DESCRIPTION
## What

Defensive hardening for `bot-auto-merge.yml`'s `approve-owner` job. It only re-polled required contexts when `CodeRabbit Gate` finished, on the assumption that `Review Verified` is the slowest required context.

## Why

That assumption broke on `docker-torrent-box-with-vpn` on 2026-09-10: its integration suite is gated behind a manual `/run-tests` comment, so it finished well after `CodeRabbit Gate`'s own poll window had already closed, and nothing was listening for it. Its `approve-owner` job sat stuck across four separate attempts until the same fix landed there.

`Tests` here runs synchronously in the same push as `Pre-commit`, not gated behind a manual trigger, so the assumption still holds in practice and this has not actually failed here. Carrying the fix over anyway costs nothing: naming both workflows in `workflow_run` means whichever required context finishes last is what re-triggers the poll, instead of depending on an assumption about which one that will be.

## Validation

`pre-commit run --files .github/workflows/bot-auto-merge.yml` passes, including `checklist-github-actions` (actionlint + zizmor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated pull request processing so approval checks respond consistently when required validation completes.
  * Updated workflow handling to support multiple validation checks and reduce delays in automated merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->