### PR TITLE
fix: stop proposing github-actions bumps Pin Only can never approve

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -192,6 +192,28 @@
       groupSlug: "pre-commit-hooks",
       labels: ["dependencies", "pre-commit"],
     },
+    // The github-actions manager extracts more than uses: pins by default:
+    // pull-request-validation.yml's python-version: "3.13" passed to
+    // actions/setup-python's with: (depType uses-with) is exactly what PR
+    // #82 proved live, proposing 3.13 to 3.14 with no way to ever merge it.
+    // Dependabot's github-actions ecosystem never watched this shape, it
+    // bumped uses: pins only, and scripts/assert-pin-only-diff.py's
+    // REV_PIN and ACTION_SHA patterns do not match a with: input either, so
+    // Pin Only was always going to refuse a diff like this and route it to
+    // a person, the same person it will keep routing every future Python
+    // release to, forever, unless this manager stops proposing the shape.
+    // Disabled here so this repository stops generating a pull request
+    // that can never pass its own required check, rather than leaving that
+    // outcome to repeat every time upstream Python cuts a release.
+    // matchDepTypes also covers github-runner (a literal runs-on: value)
+    // for the same reason, even though nothing here happens to use one
+    // today; docker-torrent-box-with-vpn and pre-commit-checklists-demo
+    // both carry the identical rule for the identical reason.
+    {
+      matchManagers: ["github-actions"],
+      matchDepTypes: ["github-runner", "uses-with"],
+      enabled: false,
+    },
   ],
 
   customManagers: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -207,8 +207,8 @@
     // outcome to repeat every time upstream Python cuts a release.
     // matchDepTypes also covers github-runner (a literal runs-on: value)
     // for the same reason, even though nothing here happens to use one
-    // today; docker-torrent-box-with-vpn and pre-commit-checklists-demo
-    // both carry the identical rule for the identical reason.
+    // today; pre-commit-checklists and pre-commit-checklists-demo both
+    // carry the identical rule for the identical reason.
     {
       matchManagers: ["github-actions"],
       matchDepTypes: ["github-runner", "uses-with"],


### PR DESCRIPTION
## What

Disables the `github-actions` manager's `github-runner` and `uses-with` depTypes.

## Why

#82 proved it live: `pull-request-validation.yml`'s `python-version: "3.13"` passed to `actions/setup-python`'s `with:` is a `uses-with` dependency, not a `uses:` pin. `scripts/assert-pin-only-diff.py` has no pattern for a `with:` input, so `Pin Only` correctly refused the diff and routed it to a person, exactly as designed. The problem is that every future Python release generates the identical unmergeable pull request, forever, since the shape never changes. Disabling the manager for these two depTypes stops Renovate proposing something it was never going to get approved for, rather than relying on `Pin Only`'s refusal to catch it every single time.

Same rule `docker-torrent-box-with-vpn` and `pre-commit-checklists-demo` already carry for the identical reason.

## Validation

`renovate-config-validator --strict` passes. `pre-commit run --files .github/renovate.json5` passes.

Could not get a clean `dry-run=lookup` confirmation locally that this specific dependency now shows zero proposed updates: this sandbox has no GitHub token, and every dependency in the lookup output reads `skipReason=github-token-required` regardless of this rule, which masks whichever reason actually applies first. The identical rule shape is already proven working against a real token in `pre-commit-checklists-demo`'s own merged PR, not assumed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to stop proposing incompatible GitHub Actions input-value updates.
  * Prevented recurring update requests that would fail repository validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->