### PR TITLE
fix: narrow codeql.yml to security, let managed Code Quality own quality

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,23 +1,40 @@
 ---
 name: CodeQL
 
-# CodeQL analysis of this repository's Python, with both the security and the
-# quality query suites, uploaded to the code scanning tab alongside the Trivy
-# and Docker Scout results that publish-image.yml and nightly-build.yml send
-# there.
+# CodeQL security analysis of this repository's Python, uploaded to the code
+# scanning tab alongside the Trivy and Docker Scout results that
+# publish-image.yml and nightly-build.yml send there.
 #
-# Python only, and it is worth being clear about how small that scope is,
-# because the Security tab's "Code quality findings . Disabled" prompt reads
-# like it is offering to analyze the whole repository. CodeQL supports
-# JavaScript/TypeScript, Ruby, Python, Go, Java/Kotlin, C/C++ and C#. It does
-# not support shell, and shell is what this image actually ships:
-# scripts/backup.sh, restore.sh and view.sh are the product. So CodeQL cannot
-# see the code that matters most here, and the tools that can already run on
-# every commit: shellcheck (plus shfmt and the shebang checks) through
-# `checklist-dev-shell` in .pre-commit-config.yaml, hadolint on the Dockerfile,
-# actionlint and zizmor on these workflows, and detect-secrets against
-# .secrets.baseline. docs/SECURITY.md's "What scans what" lays the whole
-# arrangement out.
+# Security only. This used to run 'security-and-quality', which was the right
+# call while nothing else covered quality; GitHub Code Quality was enabled on
+# this repository on 2026-09-09 and now runs its own GitHub-managed CodeQL
+# analysis over the same Python for exactly that. Keeping both would run the
+# quality queries twice over one small tooling directory and pay for it twice
+# in runner minutes. So the managed setup owns quality and this workflow owns
+# security. See issue #80.
+#
+# Two things about that managed analysis are worth knowing before assuming it
+# is missing. Its workflow is GitHub-generated and does not live in
+# .github/workflows/, so actionlint and zizmor never see it and it does not
+# follow this repository's permissions/SHA-pinning conventions; nothing to
+# fix, but the usual gates do not cover it. And its results have no REST API
+# at all (code-quality/alerts and code-quality/analyses both 404, and it
+# produces no code-scanning/analyses entry), so they are visible only in the
+# UI at /security/quality, which means a clean result and a broken setup look
+# identical from the outside. Confirm it ran by looking for its run under
+# Actions, not by reading the security page.
+#
+# Python only, either way, and it is worth being clear about how small that
+# scope is. CodeQL supports JavaScript/TypeScript, Ruby, Python, Go,
+# Java/Kotlin, C/C++ and C#, and Code Quality supports a subset of those. It
+# does not support shell, and shell is what this image actually ships:
+# scripts/backup.sh, restore.sh and view.sh are the product. So neither
+# analysis can see the code that matters most here, and the tools that can
+# already run on every commit: shellcheck (plus shfmt and the shebang checks)
+# through `checklist-dev-shell` in .pre-commit-config.yaml, hadolint on the
+# Dockerfile, actionlint and zizmor on these workflows, and detect-secrets
+# against .secrets.baseline. docs/SECURITY.md's "What scans what" lays the
+# whole arrangement out.
 #
 # What CodeQL does cover is the Python under scripts/ and tests/, which is
 # repository tooling rather than shipped code: it grades pull requests
@@ -66,11 +83,16 @@ jobs:
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
-          # Both suites. 'security-and-quality' is what the Security tab's
-          # "Code quality findings" prompt is actually asking for; the default
-          # ('security-extended' is not enabled here) would report only
-          # security queries and leave that entry disabled.
-          queries: security-and-quality
+          # 'security-extended' rather than the default suite, and rather than
+          # the 'security-and-quality' this used to run. Extended keeps the
+          # broader security query set, including the lower-severity and
+          # higher-false-positive queries the default omits, which is worth it
+          # over a directory this small. Dropping the input entirely would
+          # take the default suite and lose security queries as well as the
+          # quality ones, which is not the trade being made here: the quality
+          # half moved to GitHub's managed Code Quality setup, it was not
+          # given up. See this file's header and issue #80.
+          queries: security-extended
 
       - name: Analyze
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,12 +17,15 @@ name: CodeQL
 # is missing. Its workflow is GitHub-generated and does not live in
 # .github/workflows/, so actionlint and zizmor never see it and it does not
 # follow this repository's permissions/SHA-pinning conventions; nothing to
-# fix, but the usual gates do not cover it. And its results have no REST API
-# at all (code-quality/alerts and code-quality/analyses both 404, and it
-# produces no code-scanning/analyses entry), so they are visible only in the
-# UI at /security/quality, which means a clean result and a broken setup look
-# identical from the outside. Confirm it ran by looking for its run under
-# Actions, not by reading the security page.
+# fix, but the usual gates do not cover it. And it reports through its own
+# REST endpoints rather than code scanning's, which is easy to get wrong:
+# 'code-quality/setup' returns the configuration and 'code-quality/findings'
+# the results, while 'code-quality/alerts' and 'code-quality/analyses' both
+# 404 and no 'code-scanning/analyses' entry is produced at all (measured
+# 2026-09-11). So this analysis never appears in a 'code-scanning/analyses'
+# sweep, and its absence there says nothing about whether it ran; read
+# 'code-quality/findings', or the UI at /security/quality, or the run itself
+# under Actions.
 #
 # Python only, either way, and it is worth being clear about how small that
 # scope is. CodeQL supports JavaScript/TypeScript, Ruby, Python, Go,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -188,11 +188,27 @@ it supports fewer languages still (`csharp`, `go`, `java-kotlin`,
 either. Enabling it is why `codeql.yml` narrowed from `security-and-quality`
 to `security-extended`: quality moved there rather than being given up, and
 running both suites over the same small directory would have analyzed it
-twice. Its findings have no REST API and appear only in the UI at
-`/security/quality`, which makes a clean result and a broken setup look the
-same from outside; confirm it ran under Actions rather than from that page.
-AI detections (`ai_findings_option`) are deliberately left disabled, as a
-separate decision from enabling the baseline.
+twice.
+
+It reports through its own REST endpoints rather than code scanning's, which
+is worth knowing before concluding it is not running. Measured 2026-09-11:
+
+```console
+$ gh api repos/ivan-pinatti-labs/rsync-crypt/code-quality/setup
+{"state":"configured","languages":["python"],"schedule":"weekly", ...}
+$ gh api repos/ivan-pinatti-labs/rsync-crypt/code-quality/findings
+[]
+$ gh api repos/ivan-pinatti-labs/rsync-crypt/code-quality/alerts
+404
+$ gh api repos/ivan-pinatti-labs/rsync-crypt/code-quality/analyses
+404
+```
+
+It also produces no `code-scanning/analyses` entry, so it never shows up in a
+sweep of those and its absence there says nothing about whether it ran. Read
+`code-quality/findings`, the UI at `/security/quality`, or the run itself
+under Actions. AI detections (`ai_findings_option`) are deliberately left
+disabled, as a separate decision from enabling the baseline.
 
 **The Python, conversely, does not ship.** It is repository tooling: grading
 pull requests, re-resolving apk pins on an Alpine bump, auditing this file's

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -166,7 +166,8 @@ about the code this repository writes, which is scanned separately:
 | --- | --- | --- |
 | `scripts/*.sh`, `files/bash/*` | shellcheck, shfmt, shebang checks | `checklist-dev-shell`, every commit |
 | `scripts/*.py`, `tests/*.py` | ruff, flake8-bandit (`S`) rules on | `checklist-dev-python`, every commit |
-| `scripts/*.py`, `tests/*.py` | CodeQL, `security-and-quality` suite | `codeql.yml`, on merge and weekly |
+| `scripts/*.py`, `tests/*.py` | CodeQL, `security-extended` suite | `codeql.yml`, on merge and weekly |
+| `scripts/*.py`, `tests/*.py` | CodeQL quality queries | GitHub-managed Code Quality, on push, PR and weekly |
 | `Dockerfile` | hadolint | `checklist-dev-docker`, every commit |
 | `.github/workflows/*` | actionlint, zizmor | `checklist-github-actions`, every commit |
 | Everything | detect-secrets, detect-private-key | `checklist-security-credentials`, every commit |
@@ -177,8 +178,21 @@ The asymmetry there is deliberate and worth knowing before someone tries to
 rather than CodeQL because
 [CodeQL does not support shell at all](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql).
 Its languages are JavaScript/TypeScript, Ruby, Python, Go, Java/Kotlin, C/C++
-and C#. So the Security tab's "Code quality findings" prompt, which reads as
-though it would analyze the repository, can only reach the Python here.
+and C#.
+
+The Security tab's "Code quality findings" entry is a separate product, not a
+relabelling of `codeql.yml`, and it has to be enabled on its own; it was, on
+2026-09-09. It runs a GitHub-managed CodeQL analysis for quality queries, and
+it supports fewer languages still (`csharp`, `go`, `java-kotlin`,
+`javascript-typescript`, `python`, `ruby`), so it cannot see `scripts/*.sh`
+either. Enabling it is why `codeql.yml` narrowed from `security-and-quality`
+to `security-extended`: quality moved there rather than being given up, and
+running both suites over the same small directory would have analyzed it
+twice. Its findings have no REST API and appear only in the UI at
+`/security/quality`, which makes a clean result and a broken setup look the
+same from outside; confirm it ran under Actions rather than from that page.
+AI detections (`ai_findings_option`) are deliberately left disabled, as a
+separate decision from enabling the baseline.
 
 **The Python, conversely, does not ship.** It is repository tooling: grading
 pull requests, re-resolving apk pins on an Alpine bump, auditing this file's


### PR DESCRIPTION
Refs #80. The overlap half and the wrong-docs half; the post-merge verification is below and stays open on the issue until measured.

## The overlap

GitHub Code Quality was enabled on this repository on 2026-09-09 and runs its own GitHub-managed CodeQL analysis over the same Python for quality queries. Confirmed live:

```console
$ gh api repos/ivan-pinatti-labs/rsync-crypt/code-quality/setup
{"state":"configured","languages":["python"],"schedule":"weekly",
 "runner_type":"standard","runner_label":"","ai_findings_option":"disabled"}
```

...and both of its runs so far succeeded (`Code Quality: Push on main`, `Code Quality: PR #84`, event `dynamic`).

So `codeql.yml`'s `security-and-quality` was analyzing one small tooling directory for quality twice, and paying for it twice in runner minutes.

## `security-extended`, not the default

The issue offered either. Extended, because dropping the input takes the *default* suite, which is narrower than extended and would give up security queries as well as the quality ones. The quality half moved to the managed setup, it was not given up, and the suite should say so.

## The docs that were wrong

`codeql.yml`'s header and `docs/SECURITY.md:180` both explained the old choice by reference to the Security tab's "Code quality findings · Disabled" prompt, as though that prompt were asking this workflow to run the quality suite. It is not; it is a separate product that needs enabling on its own, which is what happened. Both now say so, and both carry the two facts that make it easy to misjudge from outside:

- Its workflow is GitHub-generated and does not live in `.github/workflows/`, so actionlint and zizmor never see it and it does not follow this repo's `permissions: {}` / SHA-pinning conventions. Nothing to fix; just do not expect the usual gates to cover it.
- Its results have **no REST API**: `code-quality/alerts` and `code-quality/analyses` both 404, and it produces no `code-scanning/analyses` entry. Findings appear only in the UI at `/security/quality`, so a clean result and a broken setup look identical. Confirm it ran under Actions instead.

`docs/SECURITY.md`'s "What scans what" table gains a second row for the managed analysis, and the `codeql.yml` row now reads `security-extended`.

The "CodeQL cannot analyze shell, and shell is what ships" point stays in both files and is now stated for both analyses. Code Quality supports `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby`, so it cannot see `scripts/*.sh` either; shellcheck remains the only thing covering the product.

## What is deliberately not here

- **AI detections stay off.** `ai_findings_option` is `disabled` and the issue puts enabling it out of scope, as its own decision once the quality baseline is understood.
- **Nothing about shell coverage**, also out of scope per the issue.

## Post-merge verification

The issue asks for this to be measured, not assumed, and it can only be measured after this runs on `main`:

```console
$ gh api "repos/ivan-pinatti-labs/rsync-crypt/code-scanning/analyses" \
    --jq '.[]|select(.category=="codeql-python")|[.created_at,.rules_count]|@tsv'
2026-09-10T21:35:17Z    172    # 0d79db7, the baseline to compare against
```

172 across the last six analyses. A drop is expected and is the point; the check is that what dropped is quality queries and not security ones, and that the managed workflow still runs and still reports. #80 stays open until that is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nzw9ui894bPJPS8AhA1vp6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Updated CodeQL analysis to use the security-focused extended query suite.
  - Clarified that GitHub-managed Code Quality analysis runs separately and has different reporting and language-coverage limitations.

- **Documentation**
  - Updated security documentation to distinguish CodeQL from managed Code Quality checks.
  - Documented supported triggers, result locations, and the fact that AI detections remain disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->