### PR TITLE
fix: recognize a first-time GitHub Actions pin as pin-only

### DIFF
--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -105,7 +105,16 @@ REV_PIN = re.compile(r"(?P<prefix>\brev:[ \t]+)" + RELEASE)
 # lookahead stops a
 # 40 character prefix of a longer hex run from matching and silently
 # swallowing the character that would have made the shapes differ.
-ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-f]{40}(?![0-9a-fA-F])")
+#
+# Case-insensitive (`[0-9a-fA-F]`, not `[0-9a-f]`): GitHub resolves a
+# `uses:` SHA the same way regardless of case, so an uppercase or
+# mixed-case SHA is just as real a pin as a lowercase one, and matching
+# only lowercase left a gap a CodeRabbit review of BARE_ACTION_VERSION
+# below found: an uppercase SHA on a first-time pin's new side fell
+# through ACTION_SHA entirely and was accepted by BARE_ACTION_VERSION's
+# generic RELEASE grammar instead, which does not check that a
+# first-time pin's target is SHA-shaped at all.
+ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-fA-F]{40}(?![0-9a-fA-F])")
 
 # A first-time `pinDigests` bump on a GitHub Action changes
 # `uses: actions/checkout@v7` to `uses: actions/checkout@<sha>` in one step:
@@ -138,11 +147,33 @@ ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-f]{40}(?![0-9a-fA-F])")
 # that SHA with `<version>` by the time this pattern runs, and `<version>`
 # itself does not start with a digit or a bare `v`, so RELEASE cannot match
 # it a second time.
+#
+# The version is its own capture group, `bare_version`, rather than folded
+# unnamed into the match, because a third CodeRabbit-class finding (found by
+# extending their own test, not reported directly) showed RELEASE alone is
+# still too permissive here: `_normalize_bare_action_version` below refuses
+# a 40 character match outright, real hex or not, because 40 characters is
+# the shape ACTION_SHA exists to own exclusively. Without that check, a
+# non-hex 40 character token, `0` followed by 39 `z`s for instance, never
+# matches ACTION_SHA (not hex) and was accepted here instead, since nothing
+# about this pattern's own grammar checked that the "version" replacing a
+# first-time pin's bare tag was ever a real SHA at all, only that it was
+# RELEASE-shaped. A real first-time pin's target is always exactly a 40
+# character SHA, ACTION_SHA's exclusive domain, so anything that length
+# reaching this pattern instead is already suspect, and refusing it outright
+# costs nothing: a length that long never occurs in a genuine bare release
+# tag either.
 BARE_ACTION_VERSION = re.compile(
     r"(?P<action_prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+)@"
-    + RELEASE
-    + r"$"
+    r"(?P<bare_version>" + RELEASE + r")$"
 )
+
+
+def _normalize_bare_action_version(match: re.Match[str]) -> str:
+    if len(match.group("bare_version")) == 40:
+        return match.group(0)
+    return f"{match.group('action_prefix')}@<version>"
+
 
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
@@ -255,7 +286,7 @@ def normalize(line: str, path: str = "") -> str:
         # structural mismatch instead of being waved through.
         return line
     line = ACTION_SHA.sub(r"\g<prefix><version>", line)
-    line = BARE_ACTION_VERSION.sub(r"\g<action_prefix>@<version>", line)
+    line = BARE_ACTION_VERSION.sub(_normalize_bare_action_version, line)
     line = REV_PIN.sub(r"\g<prefix><version>", line)
     return line
 

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -114,7 +114,20 @@ REV_PIN = re.compile(r"(?P<prefix>\brev:[ \t]+)" + RELEASE)
 # through ACTION_SHA entirely and was accepted by BARE_ACTION_VERSION's
 # generic RELEASE grammar instead, which does not check that a
 # first-time pin's target is SHA-shaped at all.
-ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-fA-F]{40}(?![0-9a-fA-F])")
+#
+# Anchored to a genuine `uses:` field at the start of the line, the same
+# anchor BARE_ACTION_VERSION uses, rather than a bare `@<sha>` matched
+# anywhere: a follow-up CodeRabbit finding on this exact pattern pointed
+# out the original, unanchored ACTION_SHA matched a 40 character hex run
+# on ANY changed workflow line, `run:` step content included, so a `run:`
+# command could change while its normalized form stayed equal, as long as
+# the line still ended in something SHA-shaped. `prefix` now captures the
+# full `uses: owner/repo@` text, not only `@`, so the dependency name
+# stays literal to the left exactly as it already did.
+ACTION_SHA = re.compile(
+    r"(?P<prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+@)"
+    r"[0-9a-fA-F]{40}(?![0-9a-fA-F])"
+)
 
 # A first-time `pinDigests` bump on a GitHub Action changes
 # `uses: actions/checkout@v7` to `uses: actions/checkout@<sha>` in one step:
@@ -262,7 +275,50 @@ APK_PIN_ANNOTATED_ARGS = apk_pin_annotated_args()
 PIN_ELIGIBLE_ARGS = RENOVATE_ANNOTATED_ARGS | APK_PIN_ANNOTATED_ARGS
 
 
-def normalize(line: str, path: str = "") -> str:
+# A YAML block scalar opener: `key: |`, `key: >`, with the optional
+# chomping (`-`/`+`) and explicit indentation (a digit) modifiers the spec
+# allows. Everything indented more than a line matching this, until a line
+# at or below its own indentation appears, is that block scalar's literal
+# content, not further YAML structure: a `run: |` step body is the shape
+# that matters here, since its content can coincidentally read exactly
+# like a `uses:` field. A CodeRabbit review found and confirmed this: an
+# indented `uses: owner/action@<sha> # v7` inside a run: | block matched
+# ACTION_SHA and BARE_ACTION_VERSION alike, treating shell text as if it
+# were a real GitHub Actions step, which a required check reading `Pin
+# Only` then approves. The Dockerfile has no YAML block scalars, so this
+# only ever matters for the ACTION_SHA/BARE_ACTION_VERSION/REV_PIN branch
+# below, never the ARG branch.
+BLOCK_SCALAR_OPENER = re.compile(r":\s*[|>][+-]?[1-9]?\s*$")
+
+
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
+def _in_block_scalar(context: list[str], indent: int) -> bool:
+    """Judge, from the lines already seen in this file's diff, whether
+    `indent` sits inside an open YAML block scalar.
+
+    Scans backward for the nearest line indented less than `indent`,
+    skipping blank lines (a block scalar can itself contain one, and its
+    zero indentation must not be mistaken for the boundary that closes the
+    scalar). Inside a block scalar if that nearer line opens one.
+    Conservatively also inside one if no such line is visible at all: the
+    diff is all this script ever sees of the file around a change, so a
+    block scalar whose own opening line sits outside the diff's context
+    cannot be told apart from one that was never open, and refusing the
+    line as a candidate pin either way is the fail closed direction, the
+    same one every other shape in this file takes when it cannot be sure.
+    """
+    for seen in reversed(context):
+        if not seen.strip():
+            continue
+        if _line_indent(seen) < indent:
+            return bool(BLOCK_SCALAR_OPENER.search(seen))
+    return True
+
+
+def normalize(line: str, path: str = "", in_block_scalar: bool = False) -> str:
     """Reduce a line to everything about it that a version bump may not change."""
     if path.endswith(".tool-versions"):
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", line)
@@ -285,6 +341,12 @@ def normalize(line: str, path: str = "") -> str:
         # returned unchanged either way, so any such edit shows up as a
         # structural mismatch instead of being waved through.
         return line
+    # Scoped to .github/workflows/: a block scalar (run: |) is a GitHub
+    # Actions workflow construct, not something .pre-commit-config.yaml's
+    # schema has, so gating that file by it too would only cost real
+    # first-time pins their context there for no matching risk.
+    if in_block_scalar and path.startswith(".github/workflows/"):
+        return line
     line = ACTION_SHA.sub(r"\g<prefix><version>", line)
     line = BARE_ACTION_VERSION.sub(_normalize_bare_action_version, line)
     line = REV_PIN.sub(r"\g<prefix><version>", line)
@@ -297,6 +359,15 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
     structural: list[str] = []
     path = None
     in_hunk = False
+    # The lines of each side of this file seen so far in the diff, in file
+    # order: what a block scalar check has to work with, since the diff
+    # never carries the whole file. Kept separate because a hunk can add or
+    # remove a block scalar's own opening line, which changes whether a
+    # later line on just one side is inside one. Reset on every file header,
+    # not every hunk, since hunks in one file's diff always appear in
+    # ascending line order and a block scalar can span more than one hunk.
+    old_context: list[str] = []
+    new_context: list[str] = []
 
     for line in diff.splitlines():
         header = FILE_HEADER.match(line)
@@ -304,6 +375,8 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
             old, new = header.group("old"), header.group("new")
             path = new
             in_hunk = False
+            old_context = []
+            new_context = []
             changes.setdefault(path, (Counter(), Counter()))
             if old != new:
                 structural.append(f"{old} renamed to {new}")
@@ -329,9 +402,22 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
             continue
 
         if line.startswith("-"):
-            changes[path][0][normalize(line[1:], path)] += 1
+            content = line[1:]
+            in_scalar = _in_block_scalar(old_context, _line_indent(content))
+            changes[path][0][normalize(content, path, in_scalar)] += 1
+            old_context.append(content)
         elif line.startswith("+"):
-            changes[path][1][normalize(line[1:], path)] += 1
+            content = line[1:]
+            in_scalar = _in_block_scalar(new_context, _line_indent(content))
+            changes[path][1][normalize(content, path, in_scalar)] += 1
+            new_context.append(content)
+        elif line.startswith(" ") or line == "":
+            # An unchanged context line: not compared itself, but part of
+            # the surrounding structure a block scalar check on a later
+            # line in this file needs to see.
+            content = line[1:] if line else line
+            old_context.append(content)
+            new_context.append(content)
 
     return changes, structural
 

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -122,6 +122,15 @@ ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-f]{40}(?![0-9a-fA-F])")
 # same name, where a CodeRabbit review found exactly that gap in an earlier,
 # unscoped version of this pattern.
 #
+# `uses:` alone is not narrow enough either, as a follow-up CodeRabbit
+# finding on this exact pattern went on to show: `\buses:` is a
+# word-boundary check, not a position check, so it matches the substring
+# "uses:" anywhere a line contains it, including inside a `run:` step's own
+# text (`run: uses: actions/checkout@v7` normalized the same way a real
+# `uses:` line did). Anchored to the start of the line instead, with only
+# an optional YAML list marker (`- `) and indentation in front of `uses:`,
+# which is the only place a real `uses:` field can sit.
+#
 # Applying ACTION_SHA first, ahead of this one, is what keeps the two from
 # double matching: RELEASE's character class is wide enough to also accept a
 # 40 character hex run as a "version", so an already-pinned line would match
@@ -130,7 +139,9 @@ ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-f]{40}(?![0-9a-fA-F])")
 # itself does not start with a digit or a bare `v`, so RELEASE cannot match
 # it a second time.
 BARE_ACTION_VERSION = re.compile(
-    r"(?P<action_prefix>\buses:[ \t]+[\w.-]+/[\w./-]+)@" + RELEASE + r"$"
+    r"(?P<action_prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+)@"
+    + RELEASE
+    + r"$"
 )
 
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -107,6 +107,32 @@ REV_PIN = re.compile(r"(?P<prefix>\brev:[ \t]+)" + RELEASE)
 # swallowing the character that would have made the shapes differ.
 ACTION_SHA = re.compile(r"(?P<prefix>@)[0-9a-f]{40}(?![0-9a-fA-F])")
 
+# A first-time `pinDigests` bump on a GitHub Action changes
+# `uses: actions/checkout@v7` to `uses: actions/checkout@<sha>` in one step:
+# there is no prior SHA to compare against. ACTION_SHA above normalizes the
+# pinned side to `@<version>`; this pattern gives the unpinned side the
+# identical placeholder, so the two sides of a first-time pin compare equal
+# the same way an ordinary SHA-to-SHA bump does.
+#
+# Requires a `uses:` field and an owner/repo-shaped coordinate immediately
+# before the `@`, not bare `@RELEASE` anywhere on the line: an unscoped
+# version would let a `run:` step's own `tool@v7` normalize the same way,
+# so that line could grow an unrelated-looking SHA and still read as a
+# first-time pin. Ported from docker-torrent-box-with-vpn's script of the
+# same name, where a CodeRabbit review found exactly that gap in an earlier,
+# unscoped version of this pattern.
+#
+# Applying ACTION_SHA first, ahead of this one, is what keeps the two from
+# double matching: RELEASE's character class is wide enough to also accept a
+# 40 character hex run as a "version", so an already-pinned line would match
+# this pattern too if it still carried its SHA. ACTION_SHA already replaces
+# that SHA with `<version>` by the time this pattern runs, and `<version>`
+# itself does not start with a digit or a bare `v`, so RELEASE cannot match
+# it a second time.
+BARE_ACTION_VERSION = re.compile(
+    r"(?P<action_prefix>\buses:[ \t]+[\w.-]+/[\w./-]+)@" + RELEASE + r"$"
+)
+
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
 # The exact shape .github/renovate.json5's custom regex manager is anchored
@@ -218,6 +244,7 @@ def normalize(line: str, path: str = "") -> str:
         # structural mismatch instead of being waved through.
         return line
     line = ACTION_SHA.sub(r"\g<prefix><version>", line)
+    line = BARE_ACTION_VERSION.sub(r"\g<action_prefix>@<version>", line)
     line = REV_PIN.sub(r"\g<prefix><version>", line)
     return line
 

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -277,18 +277,25 @@ PIN_ELIGIBLE_ARGS = RENOVATE_ANNOTATED_ARGS | APK_PIN_ANNOTATED_ARGS
 
 # A YAML block scalar opener: `key: |`, `key: >`, with the optional
 # chomping (`-`/`+`) and explicit indentation (a digit) modifiers the spec
-# allows. Everything indented more than a line matching this, until a line
-# at or below its own indentation appears, is that block scalar's literal
-# content, not further YAML structure: a `run: |` step body is the shape
-# that matters here, since its content can coincidentally read exactly
-# like a `uses:` field. A CodeRabbit review found and confirmed this: an
-# indented `uses: owner/action@<sha> # v7` inside a run: | block matched
-# ACTION_SHA and BARE_ACTION_VERSION alike, treating shell text as if it
-# were a real GitHub Actions step, which a required check reading `Pin
-# Only` then approves. The Dockerfile has no YAML block scalars, so this
-# only ever matters for the ACTION_SHA/BARE_ACTION_VERSION/REV_PIN branch
-# below, never the ARG branch.
-BLOCK_SCALAR_OPENER = re.compile(r":\s*[|>][+-]?[1-9]?\s*$")
+# allows, in either order (`|2-` and `|-2` are both valid YAML), and an
+# optional trailing comment after them. Everything indented more than a
+# line matching this, until a line at or below its own indentation
+# appears, is that block scalar's literal content, not further YAML
+# structure: a `run: |` step body is the shape that matters here, since
+# its content can coincidentally read exactly like a `uses:` field. A
+# CodeRabbit review found and confirmed this: an indented `uses:
+# owner/action@<sha> # v7` inside a run: | block matched ACTION_SHA and
+# BARE_ACTION_VERSION alike, treating shell text as if it were a real
+# GitHub Actions step, which a required check reading `Pin Only` then
+# approves. A later review round found the first regex here only matched
+# one modifier order and no trailing comment, so `run: |2-  # step body`
+# or `run: |-2` opened a block scalar this check could not recognize as
+# one. The Dockerfile has no YAML block scalars, so this only ever
+# matters for the ACTION_SHA/BARE_ACTION_VERSION/REV_PIN branch below,
+# never the ARG branch.
+BLOCK_SCALAR_OPENER = re.compile(
+    r":\s*[|>](?:[+-][1-9]?|[1-9][+-]?)?(?:[ \t]+#.*)?\s*$"
+)
 
 
 def _line_indent(line: str) -> int:
@@ -309,6 +316,24 @@ def _in_block_scalar(context: list[str], indent: int) -> bool:
     cannot be told apart from one that was never open, and refusing the
     line as a candidate pin either way is the fail closed direction, the
     same one every other shape in this file takes when it cannot be sure.
+
+    A CodeRabbit review named the residual gap in this precisely: the
+    first shallower line found is trusted as the boundary even when it is
+    itself ordinary scalar content one level further out, rather than the
+    real opener sitting deeper in the scan, so a `uses:` line nested under
+    something like an `if` inside a `run: |` block, both indented past the
+    block's own floor, is not caught. Scanning past a shallower non-opener
+    line to keep looking, rather than trusting it as decisive, would close
+    that gap, but was tried and reverted: it also requires reaching the
+    file's own top level (indentation zero) before a real diff's limited
+    context ever earns a confident "not inside one", and no ordinary `gh
+    pr diff` output carries that much. Verified against
+    docker-torrent-box-with-vpn's own #178, whose real diff never contains
+    the change's enclosing indentation chain down to indentation zero: the
+    deeper version refused it outright, the same result a compromised
+    bot's diff should get, not a clean one. This narrower version is the
+    one actually deployed; the nested case above is an accepted,
+    documented gap rather than a silently unfixed one.
     """
     for seen in reversed(context):
         if not seen.strip():
@@ -359,13 +384,21 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
     structural: list[str] = []
     path = None
     in_hunk = False
-    # The lines of each side of this file seen so far in the diff, in file
-    # order: what a block scalar check has to work with, since the diff
-    # never carries the whole file. Kept separate because a hunk can add or
-    # remove a block scalar's own opening line, which changes whether a
-    # later line on just one side is inside one. Reset on every file header,
-    # not every hunk, since hunks in one file's diff always appear in
-    # ascending line order and a block scalar can span more than one hunk.
+    # The lines of each side of this file seen so far in the current hunk,
+    # in file order: what a block scalar check has to work with, since the
+    # diff never carries the whole file. Kept separate because a hunk can
+    # add or remove a block scalar's own opening line, which changes
+    # whether a later line on just one side is inside one. Reset on every
+    # hunk header, not only every file header: a hunk boundary means the
+    # diff skips lines in between, and a line just past the gap could
+    # otherwise be judged against context from before it, a shallower line
+    # left over from the previous hunk that is not actually the nearest
+    # one to the real file. Kept context from the file's earlier hunks
+    # cannot be trusted to still be the true boundary once the diff has
+    # jumped past lines neither side of this comparison ever saw; starting
+    # each hunk with nothing visible falls back to the same fail closed
+    # default `_in_block_scalar` already takes when a file's first hunk
+    # opens with no context at all.
     old_context: list[str] = []
     new_context: list[str] = []
 
@@ -384,6 +417,8 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
 
         if line.startswith("@@"):
             in_hunk = True
+            old_context = []
+            new_context = []
             continue
 
         # Everything between a file header and its first hunk is preamble: the

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -52,9 +52,14 @@ def _diff(path: str, body: str, *, header: str = "") -> str:
 
 
 def test_accepts_a_github_action_sha_bump():
+    # A real `gh pr diff` always carries a line or two of unchanged context
+    # around a change; the leading ` - name: Checkout` here mirrors that,
+    # since _in_block_scalar conservatively refuses a candidate pin when the
+    # diff shows it no visible context at all to judge from.
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            f"       - name: Checkout\n"
             f"-        uses: actions/checkout@{SHA} # v7\n"
             f"+        uses: actions/checkout@{OTHER_SHA} # v7\n",
         )
@@ -70,6 +75,7 @@ def test_accepts_a_first_time_github_action_pin():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            f"       - name: Checkout\n"
             f"-        uses: actions/checkout@v7\n"
             f"+        uses: actions/checkout@{SHA}\n",
         )
@@ -84,6 +90,7 @@ def test_accepts_a_first_time_pin_as_a_yaml_list_item():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            f"     steps:\n"
             f"-      - uses: actions/checkout@v7\n"
             f"+      - uses: actions/checkout@{SHA}\n",
         )
@@ -96,11 +103,28 @@ def test_accepts_an_uppercase_first_time_pin():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            f"       - name: Checkout\n"
             f"-        uses: actions/checkout@v7\n"
             f"+        uses: actions/checkout@{SHA.upper()}\n",
         )
     )
     assert result.returncode == 0, result.stdout
+
+
+def test_refuses_a_first_time_pin_with_no_visible_context():
+    # _in_block_scalar has nothing to judge from when the diff shows no
+    # line shallower than the change at all (a synthetic edge case a real
+    # gh pr diff essentially never produces, since it always carries a
+    # line or two of context), and conservatively refuses rather than
+    # guess, the same fail closed direction every other shape here takes.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-        uses: actions/checkout@v7\n"
+            f"+        uses: actions/checkout@{SHA}\n",
+        )
+    )
+    assert result.returncode == 1
 
 
 def test_refuses_a_non_hex_40_character_token_as_a_first_time_pin():

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -62,6 +62,21 @@ def test_accepts_a_github_action_sha_bump():
     assert result.returncode == 0, result.stdout
 
 
+def test_accepts_a_first_time_github_action_pin():
+    # pinDigests adding a SHA to a previously unpinned action, ported from
+    # docker-torrent-box-with-vpn's own PR #178/#183: there is no prior SHA
+    # to compare against, and ACTION_SHA alone had no pattern for that
+    # transition.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-        uses: actions/checkout@v7\n"
+            f"+        uses: actions/checkout@{SHA}\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
 def test_accepts_a_pre_commit_hook_rev_bump():
     result = _check(
         _diff(
@@ -230,6 +245,33 @@ def test_refuses_a_swapped_name_at_the_same_version():
             ".github/workflows/pull-request-validation.yml",
             f"-        uses: actions/checkout@{SHA}\n"
             f"+        uses: attacker/checkout@{SHA}\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+def test_refuses_a_first_time_pin_with_a_swapped_owner():
+    # The dependency name stays literal to the left of the `@` for this
+    # shape exactly as it does for every other pin type here.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-        uses: actions/checkout@v7\n+        uses: evil/checkout@{SHA}\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+def test_refuses_a_run_step_version_bump_disguised_as_a_first_time_pin():
+    # BARE_ACTION_VERSION requires a uses: field and an owner/repo
+    # coordinate, not bare `@RELEASE` anywhere on the line: a run: step's
+    # trailing tool@v7 must not normalize the same way a first-time action
+    # pin does, or that line could grow an unrelated-looking SHA and still
+    # read as pin-only.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-          run: tool@v7\n+          run: tool@{SHA}\n",
         )
     )
     assert result.returncode == 1

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -77,6 +77,20 @@ def test_accepts_a_first_time_github_action_pin():
     assert result.returncode == 0, result.stdout
 
 
+def test_accepts_a_first_time_pin_as_a_yaml_list_item():
+    # A step is also legally written as a bare list item, `- uses: ...`,
+    # with no name: line above it. The anchor has to allow the optional
+    # marker, not just plain indentation.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-      - uses: actions/checkout@v7\n"
+            f"+      - uses: actions/checkout@{SHA}\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
 def test_accepts_a_pre_commit_hook_rev_bump():
     result = _check(
         _diff(
@@ -272,6 +286,23 @@ def test_refuses_a_run_step_version_bump_disguised_as_a_first_time_pin():
         _diff(
             ".github/workflows/pull-request-validation.yml",
             f"-          run: tool@v7\n+          run: tool@{SHA}\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+def test_refuses_uses_embedded_in_a_run_step_disguised_as_a_first_time_pin():
+    # CodeRabbit's follow-up finding: \buses: is a word-boundary check, not
+    # a position check, so it matched the substring "uses:" anywhere on the
+    # line, including inside a run: step's own text. BARE_ACTION_VERSION now
+    # anchors to the start of the line, so a run: step that happens to
+    # contain the literal text "uses: owner/repo@version" cannot disguise
+    # itself as a real uses: field this way.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-          run: uses: actions/checkout@v7\n"
+            f"+          run: uses: actions/checkout@{SHA}\n",
         )
     )
     assert result.returncode == 1

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -91,6 +91,36 @@ def test_accepts_a_first_time_pin_as_a_yaml_list_item():
     assert result.returncode == 0, result.stdout
 
 
+def test_accepts_an_uppercase_first_time_pin():
+    # GitHub resolves a uses: SHA the same way regardless of case.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-        uses: actions/checkout@v7\n"
+            f"+        uses: actions/checkout@{SHA.upper()}\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_refuses_a_non_hex_40_character_token_as_a_first_time_pin():
+    # A third finding on this pattern: RELEASE accepts any alphanumeric
+    # run, hex or not, so a 40 character token that is not real hex slips
+    # past ACTION_SHA (not hex) and was accepted here regardless, since
+    # nothing checked that a first-time pin's target was ever a real SHA.
+    # 40 characters is the shape ACTION_SHA exists to own exclusively, so
+    # anything that length reaching this pattern is refused outright.
+    fake = "0" + "z" * 39
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-        uses: actions/checkout@v7\n"
+            f"+        uses: actions/checkout@{fake}\n",
+        )
+    )
+    assert result.returncode == 1
+
+
 def test_accepts_a_pre_commit_hook_rev_bump():
     result = _check(
         _diff(


### PR DESCRIPTION
## What

Teaches `scripts/assert-pin-only-diff.py` to recognize a first-time GitHub Actions SHA pin (an unpinned `uses: actions/checkout@v7` becoming `uses: actions/checkout@<sha>`) as a valid pin-only shape, alongside the SHA-to-SHA bump it already recognized.

## Why

Ported from docker-torrent-box-with-vpn's PR #178/#183. Renovate's `pinDigests` update type adds a SHA where there was previously only a bare tag, and `ACTION_SHA` had no pattern for that transition: there's no prior SHA to compare against, so the unpinned side never matched the pinned side, and `Pin Only` refused the diff permanently (no bypass actor exists on this repository's branch protection, so a bot-authored PR of this shape can never turn the required check green on its own).

Nothing here is currently exposed to it: every action in this repository is already SHA-pinned. But the gap is permanent for whichever action gets added next without being hand-pinned first, the same trap that sat docker-torrent-box-with-vpn#178 unmergeable until this shape was recognized there.

`BARE_ACTION_VERSION` normalizes the unpinned side to the identical `@<version>` placeholder `ACTION_SHA` already produces for the pinned side. Scoped to a `uses:` field and an owner/repo coordinate immediately before the `@`, not bare `@RELEASE` anywhere on the line, per a CodeRabbit finding on docker-torrent-box-with-vpn's own PR: an unscoped version would let a `run:` step's own `tool@v7` normalize the same way, so that line could grow an unrelated-looking SHA and still read as pin-only.

## Validation

- Two new tests: the accepted shape, and a swapped owner still refused.
- One regression test: the `run:` step disguise CodeRabbit's finding covered.
- Full `pytest -m scripts`: 120 passed.
- `pre-commit`'s push stage: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of GitHub Action SHA pin changes, including uppercase hashes and first-time pinning.
  * Prevented unrelated version changes, invalid hashes, owner changes, and misleading text inside workflow script blocks from being accepted.
  * Preserved workflow script content during pin-only diff checks, including scripts using multiline formatting.

* **Tests**
  * Added coverage for valid first-time pins, YAML list syntax, uppercase hashes, missing context, invalid values, and unrelated changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->