### PR TITLE
fix: recognize standalone sequence item block scalar headers

### DIFF
--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -275,7 +275,8 @@ APK_PIN_ANNOTATED_ARGS = apk_pin_annotated_args()
 PIN_ELIGIBLE_ARGS = RENOVATE_ANNOTATED_ARGS | APK_PIN_ANNOTATED_ARGS
 
 
-# A YAML block scalar opener: `key: |`, `key: >`, with the optional
+# A YAML block scalar opener: `key: |`, `key: >`, or a bare sequence item
+# whose own value is the scalar (`- |`, `- >-`), with the optional
 # chomping (`-`/`+`) and explicit indentation (a digit) modifiers the spec
 # allows, in either order (`|2-` and `|-2` are both valid YAML), and an
 # optional trailing comment after them. Everything indented more than a
@@ -290,11 +291,16 @@ PIN_ELIGIBLE_ARGS = RENOVATE_ANNOTATED_ARGS | APK_PIN_ANNOTATED_ARGS
 # approves. A later review round found the first regex here only matched
 # one modifier order and no trailing comment, so `run: |2-  # step body`
 # or `run: |-2` opened a block scalar this check could not recognize as
-# one. The Dockerfile has no YAML block scalars, so this only ever
-# matters for the ACTION_SHA/BARE_ACTION_VERSION/REV_PIN branch below,
-# never the ARG branch.
+# one. A further review found it still missed a standalone sequence-item
+# scalar header, `- |` with no `key:` in front at all, since the pattern
+# required a colon before the scalar indicator; confirmed exploitable the
+# same way, a `uses:` line nested under one read as ordinary YAML
+# structure instead of a block scalar's literal content. The Dockerfile
+# has no YAML block scalars, so this only ever matters for the
+# ACTION_SHA/BARE_ACTION_VERSION/REV_PIN branch below, never the ARG
+# branch.
 BLOCK_SCALAR_OPENER = re.compile(
-    r":\s*[|>](?:[+-][1-9]?|[1-9][+-]?)?(?:[ \t]+#.*)?\s*$"
+    r"(?::|^[ \t]*-)\s*[|>](?:[+-][1-9]?|[1-9][+-]?)?(?:[ \t]+#.*)?\s*$"
 )
 
 

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -575,3 +575,23 @@ def test_refuses_an_annotated_arg_losing_its_default():
         )
     )
     assert result.returncode == 1, result.stdout
+
+
+def test_refuses_a_first_time_pin_disguise_inside_a_sequence_item_scalar():
+    # A CodeRabbit review found BLOCK_SCALAR_OPENER itself was still too
+    # narrow: it required a colon before the scalar indicator, so a bare
+    # sequence-item header with no key in front, `- |`, was not
+    # recognized as opening a block scalar. A uses: line nested under one
+    # then reached pin normalization as ordinary YAML structure instead
+    # of literal block scalar content. Confirmed exploitable before
+    # BLOCK_SCALAR_OPENER also matched a standalone sequence-item header.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "        scripts:\n"
+            "          - |\n"
+            "-            uses: fake/action@v7\n"
+            "+            uses: fake/action@v8\n",
+        )
+    )
+    assert result.returncode == 1, result.stdout


### PR DESCRIPTION
Follow up to #87, which merged before this finding was surfaced by a later CodeRabbit review round on the sibling copies of this script.

BLOCK_SCALAR_OPENER required a colon before the scalar indicator, so a bare sequence item header with no key in front, `- |` or `- >-`, was not recognized as opening a block scalar. A uses: line nested under one then reached pin normalization as ordinary YAML structure instead of literal block scalar content, letting a disguised non pin change read as pin only.

Confirmed exploitable before this fix. Added a regression test reproducing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of changes hidden inside YAML block scalars introduced with standalone sequence-item markers.
  * The pin-checking validation now correctly rejects disguised first-time version changes in these scalar blocks.

* **Tests**
  * Added coverage for pin changes nested under sequence-item block scalar headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->