### PR TITLE
docs: stop attributing the release step to an action it no longer uses

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -82,9 +82,9 @@ jobs:
     timeout-minutes: 3
     permissions:
       # Explicit API dispatch, not a stored credential: the release above is
-      # created with the default GITHUB_TOKEN (no 'token:' override on
-      # ncipollo/release-action), and GitHub does not start new workflow runs
-      # from an event a GITHUB_TOKEN created, release creation included, to
+      # created by 'gh release create' with GH_TOKEN set to the default
+      # GITHUB_TOKEN, and GitHub does not start new workflow runs from an
+      # event a GITHUB_TOKEN created, release creation included, to
       # stop workflows retriggering each other in a loop. That would leave
       # publish-image.yml's 'release: published' trigger permanently unfired
       # for every release this workflow itself creates. The documented

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -10,8 +10,8 @@ name: Publish Image
 #
 #   - create-tag (mathieudutour/github-tag-action) computes the next semver
 #     tag and creates the git tag.
-#   - create-release (ncipollo/release-action) turns that tag into a GitHub
-#     Release.
+#   - create-release (gh release create, falling back to gh release edit if
+#     the tag already carries one) turns that tag into a GitHub Release.
 #
 # 'release: published' fires once that second job finishes, and its payload
 # (github.event.release.tag_name) already carries the exact tag create-tag
@@ -29,11 +29,11 @@ name: Publish Image
 # gap.
 #
 # It is also, on its own, a trigger that never fires for the release
-# merge.yml actually creates. create-release calls ncipollo/release-action
-# with no 'token:' override, so it defaults to GITHUB_TOKEN, and GitHub does
-# not start new workflow runs from an event a GITHUB_TOKEN created, release
-# creation through the API included, specifically to stop workflows
-# triggering each other in a loop. This is the exact same restriction
+# merge.yml actually creates. create-release runs 'gh release create' with
+# GH_TOKEN set to the default GITHUB_TOKEN, and GitHub does not start new
+# workflow runs from an event a GITHUB_TOKEN created, release creation
+# through the API included, specifically to stop workflows triggering each
+# other in a loop. This is the exact same restriction
 # CLAUDE.md documents for resolve-apk-pins.yml's push, and the fix is the
 # same shape: merge.yml's own 'trigger-image-publish' job explicitly
 # dispatches this workflow right after create-release finishes, via


### PR DESCRIPTION
Follow-up to #88, which replaced `ncipollo/release-action` with `gh release create` and closed #71. Three comments elsewhere still describe the release as ncipollo's.

## What was wrong

Two are in `publish-image.yml`'s header, which is the file someone reads to work out how a merge becomes a published image:

- The job summary named `ncipollo/release-action` as what turns the tag into a Release.
- The explanation of why `release: published` never fires on its own rested on *"create-release calls ncipollo/release-action with no `token:` override, so it defaults to GITHUB_TOKEN"*.

The third is that same claim in `merge.yml`'s own `trigger-image-publish` permissions comment.

## What is unaffected

The reasoning, entirely. `gh release create` runs with `GH_TOKEN` set to the default `GITHUB_TOKEN`, so GitHub still refuses to start new workflow runs from the release it creates, and the explicit `workflow_dispatch` is still what bridges that gap. Only the attribution was wrong.

That is the worse kind of stale comment, though: it reads as a fact about the current code and sends the reader hunting for a `token:` input on an action that is no longer in the file. A comment that is merely out of date is survivable; one that is now false costs whoever trusts it.

## Deliberately kept

The three remaining `ncipollo` mentions in `merge.yml` stay. They explain why the step is written the way it is, which is history the code still depends on rather than a description of it:

- why `gh` over the action (it drops a third party from the trust boundary rather than suppressing the finding),
- which ncipollo behaviour the create-then-edit fallback reproduces (`allowUpdates: true`),
- and which one it cannot (`generateReleaseNotes`, since `--generate-notes` is create-only), plus why nothing is lost by that.

Delete those and the next person re-derives the same reasoning from scratch, or worse, "simplifies" the fallback away.

## Verification

`pre-commit run --all-files` exits 0, actionlint and zizmor included. Comments only; no workflow logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nzw9ui894bPJPS8AhA1vp6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow comments to accurately describe the release creation process and fallback behavior.
  * Clarified how GitHub token event suppression applies to automated release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->