### PR TITLE
chore: move CI Python to 3.14 and pin ruff's target to it

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: tests/requirements.txt
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,14 +14,21 @@
 # it ships in the image, which deliberately installs no Python interpreter,
 # but it does gate merges, so a bug here can wave through a bad change.
 
-# Match the interpreter CI actually uses (`python-version: "3.13"` in
-# .github/workflows/pull-request-validation.yml) rather than letting ruff infer
-# one, so a rule that depends on the target version resolves the same locally
-# and in CI. This is also what makes `UP` safe to enable: it rewrites to
-# idioms that only exist from this version onwards, `datetime.UTC` (3.11+)
-# among them, so the target has to be honest or the fixes it suggests would
-# break on the interpreter that runs them.
-target-version = "py313"
+# Match the interpreter CI actually uses (the `python-version` passed to
+# actions/setup-python in .github/workflows/pull-request-validation.yml) rather
+# than letting ruff infer one, so a rule that depends on the target version
+# resolves the same locally and in CI. This is also what makes `UP` safe to
+# enable: it rewrites to idioms that only exist from this version onwards,
+# `datetime.UTC` (3.11+) among them, so the target has to be honest or the
+# fixes it suggests would break on the interpreter that runs them.
+#
+# Nothing derives this value from that one, and no dependency bot watches
+# either any more: .github/renovate.json5 disables the github-actions
+# manager's `uses-with` depType, because a `with:` input is not a pin position
+# `Pin Only` can grade, so a Python bump here is a hand edit of both files
+# forever. tests/test_python_version_pin.py fails when they disagree, which is
+# what keeps the pair honest without anyone having to remember.
+target-version = "py314"
 
 line-length = 88
 

--- a/tests/test_python_version_pin.py
+++ b/tests/test_python_version_pin.py
@@ -1,0 +1,65 @@
+"""Keep ruff's target interpreter and CI's interpreter from drifting apart.
+
+`ruff.toml`'s `target-version` decides which idioms `UP` rewrites to and which
+version-dependent rules fire; `python-version` in
+.github/workflows/pull-request-validation.yml decides which interpreter
+actually runs the tests and the hooks. Neither value is derived from the
+other, so the pair can silently disagree, and the failure is quiet in the
+worse direction: ruff grading against an older interpreter than CI runs keeps
+passing while suggesting fixes the real interpreter is free to break on.
+
+Nothing watches either value automatically. Renovate's github-actions manager
+does propose `uses-with` bumps of exactly this shape, and .github/renovate.json5
+disables that depType on purpose, because a `with:` input is not a pin position
+`scripts/assert-pin-only-diff.py` can grade, so `Pin Only` refuses the diff and
+the pull request can never merge (PR #82 proved it live). That makes every
+future Python bump here a hand edit of two files, which is precisely the kind
+of pairing a person forgets. This test is the reminder.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github/workflows/pull-request-validation.yml"
+RUFF_CONFIG = REPO_ROOT / "ruff.toml"
+
+# `python-version: "3.14"`, quoted, as actions/setup-python is given it. The
+# quotes are not optional in the workflow and not optional here either: YAML
+# reads a bare 3.10 as the float 3.1, so an unquoted value is a bug worth
+# failing on rather than a spelling to accept.
+WORKFLOW_PYTHON = re.compile(
+    r'^\s*python-version:\s*"(?P<major>\d+)\.(?P<minor>\d+)"\s*$', re.MULTILINE
+)
+
+# `target-version = "py314"`, at the top level of ruff.toml.
+RUFF_TARGET = re.compile(
+    r'^target-version\s*=\s*"py(?P<major>\d)(?P<minor>\d+)"\s*$', re.MULTILINE
+)
+
+
+def test_workflow_declares_exactly_one_python_version():
+    """More than one would make "the interpreter CI uses" ambiguous."""
+    matches = WORKFLOW_PYTHON.findall(WORKFLOW.read_text())
+    assert len(matches) == 1, (
+        f"expected exactly one quoted python-version in {WORKFLOW.name}, "
+        f"found {len(matches)}: {matches}"
+    )
+
+
+def test_ruff_target_matches_the_interpreter_ci_runs():
+    workflow = WORKFLOW_PYTHON.search(WORKFLOW.read_text())
+    assert workflow, f"no quoted python-version found in {WORKFLOW.name}"
+
+    ruff = RUFF_TARGET.search(RUFF_CONFIG.read_text())
+    assert ruff, f"no target-version found in {RUFF_CONFIG.name}"
+
+    ci = (workflow.group("major"), workflow.group("minor"))
+    target = (ruff.group("major"), ruff.group("minor"))
+    assert ci == target, (
+        f"{RUFF_CONFIG.name} targets py{target[0]}{target[1]} but "
+        f"{WORKFLOW.name} runs Python {ci[0]}.{ci[1]}. Both have to move "
+        "together; nothing derives one from the other."
+    )


### PR DESCRIPTION
Supersedes #82.

Renovate proposed this bump in #82 and it could never merge. `python-version`
passed to `actions/setup-python` is a `with:` input, not a pin position
`scripts/assert-pin-only-diff.py` knows how to grade, so `Pin Only` refused the
diff and routed it to a person. #84 then disabled the github-actions manager's
`uses-with` depType so the shape stops being proposed at all, which makes every
future Python bump a hand edit. This is that hand edit.

## What changed

- `.github/workflows/pull-request-validation.yml`: `python-version` 3.13 to 3.14.
- `ruff.toml`: `target-version` moves with it, `py313` to `py314`. The two are
  not derived from each other, and ruff grading against an older interpreter
  than the tests run on fails quietly in the direction that keeps passing: `UP`
  goes on suggesting rewrites checked against the wrong version. The comment
  above it stops restating the workflow's literal version, which would rot on
  the next bump.
- `tests/test_python_version_pin.py`: new, fails when the pair disagrees, so
  nobody has to remember the coupling. Also asserts the workflow declares
  exactly one quoted `python-version` (unquoted, YAML reads `3.10` as the float
  `3.1`).

## Verification

Run locally on Python 3.14.7:

- `python3 -m pytest tests/ -q`: 251 passed.
- `pre-commit run --all-files`: all hooks pass.
- `ruff check --target-version py314 scripts/ tests/`: clean.
- Drift check confirmed negative as well as positive: reverting `ruff.toml` to
  `py313` alone makes `test_ruff_target_matches_the_interpreter_ci_runs` fail.

`Pin Only` passes here because this is not a bot pull request; the check grades
only `renovate[bot]`'s own non-fork diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated test environment and code-quality checks to target Python 3.14.

* **Tests**
  * Added validation to ensure the CI Python version and code-quality tooling remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->