### PR TITLE
fix: give view.sh and restore.sh a private per-session temp directory

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -59,9 +59,19 @@ __restore_paths_file=${10:-"/restore/restore-paths.txt"}                 # paths
 readonly __restore_origin="${__remote_server}:${__backup_remote_folder}" # rsync origin dir
 
 # RESTORE_PATHS env var override: if set, write to temp file and use instead of paths file
+#
+# The temp file used to be a fixed path directly under /tmp, so two restores
+# running at once wrote the same name and each could read the other's path
+# list, and the file was left behind afterwards. mktemp -d gives this run its
+# own directory, created 0700 under a name nothing can predict, and the trap
+# removes it however the script ends.
 if [ -n "${RESTORE_PATHS:-}" ]; then
-  printf '%s' "${RESTORE_PATHS}" | tr ' ' '\n' >/tmp/restore-paths-override.txt
-  __restore_paths_file="/tmp/restore-paths-override.txt"
+  __restore_tmp_dir="$(mktemp -d)"
+  # Best-effort teardown after the outcome is already decided, which is why
+  # this is not the general error suppression this repository avoids.
+  trap 'rm -rf "${__restore_tmp_dir}"' EXIT
+  __restore_paths_file="${__restore_tmp_dir}/restore-paths-override.txt"
+  printf '%s' "${RESTORE_PATHS}" | tr ' ' '\n' >"${__restore_paths_file}"
 fi
 
 # display rsync rate

--- a/scripts/view.sh
+++ b/scripts/view.sh
@@ -2,7 +2,7 @@
 
 : ' Script to browse the encrypted remote backup read-only via sshfs + gocryptfs.
     The decrypted view is served over SFTP on port 22 (mapped to host port 2222).
-    Connect Thunar to: sftp://root@localhost:2222/view/dec
+    Connect Thunar to the decrypted mount point, sftp://root@localhost:2222
     # exit(s) status code(s)
     0 - success
     1 - fail
@@ -54,10 +54,60 @@ __view_enc_folder=${4:-"/gocrypt-view/encrypted"} # sshfs mount point (remote en
 __view_dec_folder=${5:-"/gocrypt-view/decrypted"} # gocryptfs mount point (decrypted read-only view)
 
 #===============================================================
+# Per-session private scratch directory
+#===============================================================
+
+# sshd's config and the host key it is given used to be written to fixed
+# paths directly under /tmp. Two runs then share one name: the second
+# overwrites the first's host key while the first is still serving with it,
+# and the material sits somewhere any other process on that /tmp can predict
+# rather than somewhere only this run can reach. mktemp -d gives each run its
+# own directory, created 0700 under a name nothing can guess ahead of time,
+# and __view_cleanup below removes it.
+__view_tmp_dir="$(mktemp -d)"
+__view_sshd_config="${__view_tmp_dir}/sshd_config"
+__view_host_key="${__view_tmp_dir}/ssh_host_ed25519_key"
+
+#===============================================================
+# Teardown, shared by the signal trap, the exit trap and the normal path
+#===============================================================
+
+# Guarded so it is safe to run more than once: the normal path calls it, and
+# the EXIT trap fires afterwards regardless. Without the guard an interrupt
+# would run it twice in a row, and the second pkill would report failure
+# under errexit.
+__view_cleaned=false
+
+# The `|| true`s here are not the general error suppression this repository
+# avoids. This is best-effort teardown, running after the outcome is already
+# decided, and every command in it is expected to fail in the ordinary case:
+# an early exit unmounts nothing because nothing was mounted yet, and pkill
+# returns non-zero when no sshd was ever started. Without them errexit would
+# abort partway and leak the mounts and the scratch directory that the
+# function exists to remove.
+__view_cleanup() {
+  if [ "${__view_cleaned}" = true ]; then
+    return 0
+  fi
+  __view_cleaned=true
+
+  pkill -f "sshd -f ${__view_sshd_config}" 2>/dev/null || true
+  pkill -f "internal-sftp" 2>/dev/null || true
+  sleep 1
+  fusermount -u "${__view_dec_folder}" 2>/dev/null || true
+  fusermount -u "${__view_enc_folder}" 2>/dev/null || true
+  rm -rf "${__view_tmp_dir}"
+}
+
+#===============================================================
 # Set a trap for CTRL+C to properly exit
 #===============================================================
 
-trap 'echo "View interrupted, cleaning up..."; pkill -f "sshd -f /tmp/sshd_config" 2>/dev/null || true; pkill -f "internal-sftp" 2>/dev/null || true; sleep 1; fusermount -u "${__view_dec_folder}" 2>/dev/null || true; fusermount -u "${__view_enc_folder}" 2>/dev/null || true; exit 3' SIGINT SIGTERM
+trap 'echo "View interrupted, cleaning up..."; __view_cleanup; exit 3' SIGINT SIGTERM
+
+# Every other way out, including the early exits below, which previously left
+# the scratch directory behind.
+trap '__view_cleanup' EXIT
 
 #===============================================================
 # Guard: enc/dec must be empty before mounting
@@ -116,25 +166,30 @@ fi
 ssh-keygen -y -f /root/.ssh/id_rsa >/root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
 
-# Generate a temporary sshd host key (discarded on container exit)
-ssh-keygen -t ed25519 -f /tmp/ssh_host_ed25519_key -N ""
+# Generate a per-session sshd host key inside the private scratch directory
+ssh-keygen -t ed25519 -f "${__view_host_key}" -N ""
 
-# Write a minimal sshd config
-cat >/tmp/sshd_config <<'EOF'
+# Write a minimal sshd config. The heredoc is unquoted so the scratch paths
+# interpolate; nothing in the body below is shell-expandable other than those.
+# ForceCommand serves ${__view_dec_folder} rather than a second, hardcoded
+# copy of its default: the two agreed only because every caller passes the
+# default, and a caller that did not would have been served the wrong
+# directory.
+cat >"${__view_sshd_config}" <<EOF
 Port 22
-HostKey /tmp/ssh_host_ed25519_key
+HostKey ${__view_host_key}
 AuthorizedKeysFile /root/.ssh/authorized_keys
 PermitRootLogin prohibit-password
 PasswordAuthentication no
 Subsystem sftp internal-sftp
-ForceCommand internal-sftp -d /gocrypt-view/decrypted
+ForceCommand internal-sftp -d ${__view_dec_folder}
 EOF
 
-/usr/sbin/sshd -f /tmp/sshd_config
+/usr/sbin/sshd -f "${__view_sshd_config}"
 
 echo ""
 echo "VIEWER MODE: decrypted backup accessible via SFTP:"
-echo "  sftp://root@localhost:2222/gocrypt-view/decrypted"
+echo "  sftp://root@localhost:2222${__view_dec_folder}"
 echo ""
 echo "File manager access (open your file manager and connect to server):"
 echo "  GNOME Files / Nautilus : Other Locations → Connect to Server"
@@ -144,11 +199,7 @@ echo ""
 echo "When done, press Enter to unmount and exit."
 read -r -p ""
 
-pkill -f "sshd -f /tmp/sshd_config" 2>/dev/null || true
-pkill -f "internal-sftp" 2>/dev/null || true
-sleep 1
-fusermount -u "${__view_dec_folder}" 2>/dev/null || true
-fusermount -u "${__view_enc_folder}" 2>/dev/null || true
+__view_cleanup
 echo "Unmounted. Exiting."
 
 exit 0

--- a/tests/test_private_temp_dirs.py
+++ b/tests/test_private_temp_dirs.py
@@ -1,0 +1,114 @@
+"""Per-session files must live in a private directory, not a fixed /tmp path.
+
+`view.sh` wrote its sshd config and the host key it generates to
+`/tmp/sshd_config` and `/tmp/ssh_host_ed25519_key`, and `restore.sh` wrote its
+`RESTORE_PATHS` override to `/tmp/restore-paths-override.txt`. Fixed names
+under a shared /tmp have two consequences: a second run overwrites the first
+run's files while the first is still using them, and the material sits
+somewhere predictable rather than somewhere only that run can reach.
+
+These are static checks on the scripts rather than live runs. Proving the
+real behaviour would mean standing up sshd against a gocryptfs mount inside
+the container and racing two sessions, which is neither reproducible nor
+cheap; the failure being guarded is a path written back as a literal, so the
+literal is what gets asserted.
+
+The pkill assertion is the one that is not merely about the literal. `sshd` is
+stopped by matching its own command line, so the pattern and the `-f` argument
+have to name the same file. They agreed as two copies of one hardcoded string
+before; now they agree only because both read the same variable, and nothing
+but this test notices if a later edit reintroduces a second spelling. A pkill
+that matches nothing leaves sshd serving the decrypted view after the script
+believes it has torn everything down.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from conftest import REPO_ROOT
+
+# A path literal directly under /tmp, which is what none of these scripts may
+# carry any more. `/tmp` on its own is not matched: the scripts are free to
+# mention it in prose, and mktemp's own default lands there.
+FIXED_TMP_PATH = re.compile(r"(?<![\w$])/tmp/[\w.-]+")
+
+SCRIPTS = ["view.sh", "restore.sh", "backup.sh"]
+
+
+def _script(name):
+    return (REPO_ROOT / "scripts" / name).read_text()
+
+
+def _code_lines(body):
+    """Lines with comments stripped, so prose cannot fail a test about code."""
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        yield line.split(" #")[0]
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_no_fixed_tmp_paths(name):
+    offenders = [
+        line.strip()
+        for line in _code_lines(_script(name))
+        if FIXED_TMP_PATH.search(line)
+    ]
+    assert not offenders, (
+        f"scripts/{name} names a fixed path under /tmp: {offenders}. "
+        "Per-session files belong in a mktemp -d directory."
+    )
+
+
+def test_view_creates_a_private_scratch_directory():
+    body = _script("view.sh")
+    assert re.search(r'__view_tmp_dir="\$\(mktemp -d\)"', body), (
+        "view.sh must create its scratch directory with mktemp -d"
+    )
+    for var in ("__view_sshd_config", "__view_host_key"):
+        assert re.search(rf'{var}="\$\{{__view_tmp_dir\}}/', body), (
+            f"{var} must live inside the mktemp -d directory"
+        )
+
+
+def test_view_host_key_and_config_are_written_to_the_scratch_paths():
+    body = _script("view.sh")
+    assert 'ssh-keygen -t ed25519 -f "${__view_host_key}"' in body
+    assert 'cat >"${__view_sshd_config}"' in body
+    assert "HostKey ${__view_host_key}" in body
+
+
+def test_view_stops_the_sshd_it_started():
+    """The pkill pattern and the sshd -f argument must name the same file."""
+    body = _script("view.sh")
+    started = re.search(r"/usr/sbin/sshd -f \"(?P<path>[^\"]+)\"", body)
+    assert started, "view.sh must start sshd with a quoted config path"
+
+    killed = re.findall(r'pkill -f "sshd -f (?P<path>[^"]+)"', body)
+    assert killed, "view.sh must stop the sshd it started"
+    for pattern in killed:
+        assert pattern == started.group("path"), (
+            f"pkill matches {pattern!r} but sshd was started with "
+            f"{started.group('path')!r}; the two must be the same file, or "
+            "the running sshd survives teardown."
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "variable"),
+    [("view.sh", "__view_tmp_dir"), ("restore.sh", "__restore_tmp_dir")],
+)
+def test_scratch_directory_is_removed_on_exit(name, variable):
+    body = _script(name)
+    assert re.search(rf'rm -rf "\$\{{{variable}\}}"', body), (
+        f"scripts/{name} must remove {variable}"
+    )
+    # Leading whitespace allowed: restore.sh sets its trap inside the
+    # `if` that creates the directory, since that is its only user.
+    assert re.search(r"^\s*trap .*EXIT$", body, re.MULTILINE), (
+        f"scripts/{name} must remove it on every exit path, not only the "
+        "happy one, which takes an EXIT trap"
+    )


### PR DESCRIPTION
Closes #68.

## The problem

`view.sh` wrote its sshd config and the host key it generates to
`/tmp/sshd_config` and `/tmp/ssh_host_ed25519_key`; `restore.sh` wrote its
`RESTORE_PATHS` override to `/tmp/restore-paths-override.txt`. Fixed names under
a shared `/tmp` have two consequences, as the issue set out: a second run
overwrites the first run's files while the first is still serving with them, and
the material sits somewhere predictable rather than somewhere only that run can
reach.

## The fix

Each script creates its own `mktemp -d` directory, which arrives `0700` under an
unguessable name (verified: `stat -c %a` reports `700`), and removes it through
an `EXIT` trap so every way out is covered rather than only the happy path.

`view.sh`'s teardown moves into a guarded `__view_cleanup` shared by the signal
trap, the exit trap and the normal path. That also closes an older gap the issue
did not mention: the early `exit 1` paths (sshfs failure, missing
`gocryptfs.conf`, a non-empty mount point) previously left the enc mount and the
scratch files behind, because only `SIGINT`/`SIGTERM` had a handler.

The `|| true`s inside that function are commented as to why they are not the
general error suppression this repo avoids: it is best-effort teardown running
after the outcome is decided, and every command in it is *expected* to fail in
the ordinary case (nothing mounted yet, no sshd ever started). Without them
`errexit` aborts cleanup partway and leaks the very things it exists to remove.

## Two adjacent fixes that fall out of the heredoc

Writing the config now needs interpolation, so the heredoc stops being quoted.
That exposed a latent bug worth fixing while I was in it: `ForceCommand` carried
a second, hardcoded copy of `__view_dec_folder`'s default value, so the two
agreed only because every caller passes the default. A caller that passed
anything else would have been served the wrong directory. `ForceCommand`, the
banner, and the script's own header comment now all read the variable.

## Tests

`tests/test_private_temp_dirs.py`, static checks in the style of
`test_rsync_exit_handling.py` (proving the real behaviour would mean standing up
sshd against a gocryptfs mount and racing two sessions, which is neither
reproducible nor cheap):

- no script names a fixed path under `/tmp`, comments excluded so prose cannot
  fail a test about code;
- both of `view.sh`'s per-session files live inside the scratch directory;
- the scratch directory is removed, on an `EXIT` trap;
- **the `pkill` pattern and the `sshd -f` argument name the same file.** This is
  the one that is not merely about a literal: sshd is stopped by matching its own
  command line, and the two used to agree as two copies of one hardcoded string.
  A `pkill` that matches nothing leaves sshd serving the decrypted view after the
  script reports a clean teardown, and nothing but this test would notice a later
  edit reintroducing a second spelling.

Seven of the eight assertions fail when run against the previous scripts,
checked by restoring `main`'s copies and rerunning.

## Verification

- `python3 -m pytest tests/ -q`: 331 passed.
- `pre-commit run --all-files`: all hooks pass, `shellcheck` and `shfmt`
  included.
- `bash -n` on both scripts, plus rendering the heredoc in isolation to confirm
  the generated config carries the scratch paths.

## Not covered, and not newly so

`RESTORE_PATHS` (the env var, as opposed to `RESTORE_PATHS_FILE`) has no
functional test in the suite, before or after this change. Adding one means an
integration run, so I have left it out of a fix about file locations rather than
quietly widening the scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restore and view operations by using private, per-session temporary storage.
  - Prevented conflicts between concurrent sessions and reduced the risk of exposing temporary configuration or key files.
  - Ensured temporary files and directories are cleaned up when operations exit normally, are interrupted, or encounter termination signals.

- **Tests**
  - Added coverage verifying secure temporary-directory usage and cleanup behavior across backup, restore, and view operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->